### PR TITLE
ci: add code coverage + branch protection ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -59,11 +63,34 @@ jobs:
 
       - name: Run .NET tests (x64)
         run: |
-          dotnet test tests/LECommonLibrary.Tests/LECommonLibrary.Tests.csproj --no-build -c Debug --logger "console;verbosity=detailed"
-          dotnet test tests/LEGUI.Tests/LEGUI.Tests.csproj --no-build -c Debug --logger "console;verbosity=detailed"
+          dotnet test tests/LECommonLibrary.Tests/LECommonLibrary.Tests.csproj --no-build -c Debug --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --results-directory coverage
+          dotnet test tests/LEGUI.Tests/LEGUI.Tests.csproj --no-build -c Debug --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --results-directory coverage
 
       - name: Run LEProc.Tests (x86)
-        run: dotnet test tests/LEProc.Tests/LEProc.Tests.csproj --arch x86 -c Debug --logger "console;verbosity=detailed"
+        run: dotnet test tests/LEProc.Tests/LEProc.Tests.csproj --arch x86 -c Debug --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --results-directory coverage
+
+      # ---- Code Coverage Report ----
+
+      - name: Install ReportGenerator
+        if: '!cancelled()'
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate Coverage Report
+        if: '!cancelled()'
+        run: reportgenerator "-reports:coverage/*/coverage.cobertura.xml" "-targetdir:coveragereport" "-reporttypes:MarkdownSummaryGithub"
+        shell: pwsh
+
+      - name: Write Coverage to Job Summary
+        if: '!cancelled()'
+        run: Get-Content coveragereport/SummaryGithub.md | Add-Content $env:GITHUB_STEP_SUMMARY
+        shell: pwsh
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && !cancelled()
+        with:
+          recreate: true
+          path: coveragereport/SummaryGithub.md
 
       # ---- C++ Build ----
       # Pass SolutionDir so $(SolutionDir) resolves correctly in vcxproj OutDir

--- a/tests/LECommonLibrary.Tests/LECommonLibrary.Tests.csproj
+++ b/tests/LECommonLibrary.Tests/LECommonLibrary.Tests.csproj
@@ -15,6 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="coverlet.collector" Version="6.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/LEGUI.Tests/LEGUI.Tests.csproj
+++ b/tests/LEGUI.Tests/LEGUI.Tests.csproj
@@ -16,6 +16,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="coverlet.collector" Version="6.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/LEProc.Tests/LEProc.Tests.csproj
+++ b/tests/LEProc.Tests/LEProc.Tests.csproj
@@ -16,6 +16,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="coverlet.collector" Version="6.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #17

- Add `coverlet.collector` to all 3 .NET test projects for code coverage collection
- Configure CI to collect `XPlat Code Coverage` and generate summary via ReportGenerator
- Coverage report displayed in **GitHub Actions Job Summary** and as **sticky PR comment**
- Add `permissions: pull-requests: write` for PR comment support
- Configure **GitHub Ruleset** "Protect master" (done via UI):
  - Require `Build & Test` status check to pass
  - Block force pushes
  - Restrict deletions

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add permissions, coverage collection, ReportGenerator, Job Summary, PR comment |
| `tests/LECommonLibrary.Tests/*.csproj` | Add coverlet.collector |
| `tests/LEProc.Tests/*.csproj` | Add coverlet.collector |
| `tests/LEGUI.Tests/*.csproj` | Add coverlet.collector |

## Test plan

- [x] CI passes with coverage collection enabled
- [x] Job Summary shows coverage report
- [x] PR comment shows coverage summary (this PR itself is the test)
- [x] Ruleset blocks merge if Build & Test fails (verified via API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)