### PR TITLE
docs: 更新 README 標註專案來源、修正過時內容

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Locale Emulator
 ===============
 
-[![license](https://img.shields.io/github/license/xupefei/Locale-Emulator.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
+[![license](https://img.shields.io/github/license/ooxxTaiwan/Locale-Emulator-J.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 [![CI](https://github.com/ooxxTaiwan/Locale-Emulator-J/actions/workflows/ci.yml/badge.svg)](https://github.com/ooxxTaiwan/Locale-Emulator-J/actions/workflows/ci.yml)
 
 Yet Another System Region and Language Simulator
@@ -10,13 +10,20 @@ Yet Another System Region and Language Simulator
 
 Locale Emulator lets you run Windows applications under a different locale without changing the OS system locale. It works by hooking Windows API calls in target processes via native DLL injection.
 
-## Core Source Attribution
+## Project Origin
 
-The native hooking core (`src/Core/`) originates from [Locale-Emulator-Core](https://github.com/xupefei/Locale-Emulator-Core):
+This project is a continuation of [xupefei/Locale-Emulator](https://github.com/xupefei/Locale-Emulator), which was archived by its original author on 2022-04-15. This repository was forked from the original and has since been detached from the fork network for independent development.
 
-- **Upstream commit**: `ae7160dc5deb97947396abcd784f9b98b6ee38b3` (2021-08-23)
-- **Archive date**: 2022-04-15 (repository archived by original owner)
-- **Integration**: Source code copied directly into this repository for continued maintenance
+The native hooking core (`src/Core/`) originates from [Locale-Emulator-Core](https://github.com/xupefei/Locale-Emulator-Core) (upstream commit `ae7160d`, archived 2022-04-15), integrated directly into this repository for continued maintenance.
+
+### Major changes from the original
+
+- Migrated from .NET Framework 4.0 to **.NET 10**
+- Shell Extension rewritten from .NET COM to **native C++** (COM IShellExtInit + IContextMenu)
+- Integrated Locale-Emulator-Core source code directly into repository
+- Added CI/CD with GitHub Actions (build, test, code coverage)
+- LEUpdater removed (will be redesigned)
+- LEInstaller merged into LEGUI
 
 ## System Requirements
 
@@ -61,10 +68,14 @@ dotnet test tests/LEProc.Tests/ --arch x86    # needs Windows Desktop Runtime x8
 
 If you want to help translating Locale Emulator, you can find all strings in:
 
-- `DefaultLanguage.xaml` in `LEGUI/Lang/` folder (WPF UI)
+- `DefaultLanguage.xaml` in `src/LEGUI/Lang/` folder (WPF UI)
 - `DefaultLanguage.xml` in `src/ShellExtension/Lang/` folder (context menu)
 
-After you translated the above files into your language, please inform us by creating a pull request.
+After you translated the above files into your language, please submit a pull request.
+
+## Contributing
+
+Contributions are welcome! Feel free to open issues or submit pull requests. Please ensure CI passes before requesting review.
 
 ## License
 
@@ -75,5 +86,3 @@ After you translated the above files into your language, please inform us by cre
 - Shell Extension uses [pugixml](https://pugixml.org/) (MIT license)
 
 [Flat icon set](commit/eae9fbc27f1a4c85986577202b61742c6287e10a) from [graphicex](https://graphicex.com/icon-and-logo/15983-flat-alphabet-in-9-colors-with-long-shadow-6913875.html).
-
-If you want to make any modification on these source codes while keeping new codes not protected by LGPL-3.0, please contact us for a sublicense instead.


### PR DESCRIPTION
## 摘要

Fixes #24

Detach fork 後 GitHub 不再顯示與上游的關聯，README 需要明確標註專案來源，同時修正遷移後遺留的過時內容。

## 討論

### 1. 專案來源區段的結構

- **方案 A**：保留「Core Source Attribution」，另加「Project Origin」→ 兩段重複提及上游
- **方案 B**：整合為單一「Project Origin」區段，含 Core 來源說明
- **選擇 B**：避免重複，一個區段完整交代所有來源關係

### 2. License sublicense 聲明

- **方案 A**：改為「contact the original author」指向 xupefei
- **方案 B**：直接移除整段
- **選擇 B**：原作者已 archived repo，可能不再回覆。LGPL-3.0 授權條款本身已完整定義權利義務，額外的 sublicense 聲明是多餘的，保留反而造成困惑

### 3. README 語言

- **方案 A**：轉為中文（符合中文優先規則）
- **方案 B**：維持英文（國際開源慣例，原版 30 位貢獻者來自多國）
- **選擇 B**：README 是公開面向國際社群的文件，維持英文以利吸引貢獻者。中文優先規則適用於 PR 內容等溝通文件

### 4. Contributing 區段

- 使用者要求加入，期望有人能加入一同開發
- 簡潔撰寫：歡迎貢獻、CI 通過後再 request review

### 5. 其他文件是否需要一併修正

- 全面搜尋 `xupefei/Locale-Emulator`、`LEGUI/Lang/`、`contact us` 等關鍵字
- `docs/superpowers/` 計畫/設計文件含舊內容，但屬已執行的歷史記錄，依「計畫文件不可回頭修改」規則不動
- `src/Core/README.md` 是原版 Core 的 README，作為來源歸屬保留
- **結論：僅 README.md 需要修改**

## 變更項目

| 項目 | 變更 |
|------|------|
| Project Origin 區段 | 新增，取代 Core Source Attribution |
| License badge URL | `xupefei/Locale-Emulator` → `ooxxTaiwan/Locale-Emulator-J` |
| Translate 路徑 | `LEGUI/Lang/` → `src/LEGUI/Lang/` |
| Contributing 區段 | 新增 |
| Sublicense 聲明 | 移除 |

## 測試計畫

- [x] CI 通過
- [x] License badge 在 repo 頁面正確顯示
- [x] Project Origin 區段閱讀通順

🤖 Generated with [Claude Code](https://claude.com/claude-code)