### PR TITLE
修正 build warnings（.NET + C++）

### DIFF
--- a/src/Core/LoaderDll/LoaderDll.vcxproj
+++ b/src/Core/LoaderDll/LoaderDll.vcxproj
@@ -76,7 +76,7 @@
       <ImportLibrary>.\Release\LoaderDll.lib</ImportLibrary>
       <NoEntryPoint>true</NoEntryPoint>
       <AdditionalDependencies>undoc_ntdll.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions> /ltcg</AdditionalOptions>
+      <AdditionalOptions>/ltcg /ignore:4254</AdditionalOptions>
       <ModuleDefinitionFile>.\LoaderDll.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>

--- a/src/Core/LocaleEmulator/Hooks/Gdi32Hook.cpp
+++ b/src/Core/LocaleEmulator/Hooks/Gdi32Hook.cpp
@@ -172,7 +172,7 @@ HGDIOBJ NTAPI LeGetStockObject(LONG Object)
 
         auto StockObjectIndexLast = StockObjectIndex + countof(StockObjectIndex);
 
-        if (std::find(StockObjectIndex, StockObjectIndexLast, Object) != StockObjectIndexLast) {
+        if (std::find(StockObjectIndex, StockObjectIndexLast, (ULONG_PTR)Object) != StockObjectIndexLast) {
             PROTECT_SECTION(&GlobalData->HookRoutineData.Gdi32.GdiLock) {
                 if (StockObject == nullptr)
                     return StockObject = GetFontFromFont(GlobalData, (HFONT)GlobalData->GetStockObject(Object));
@@ -833,7 +833,7 @@ NTSTATUS LeGlobalData::HookGdi32Routines(PVOID Gdi32)
         if (Win32uMod == nullptr)
             return STATUS_NOT_FOUND;
         NtGdiHfontCreate = Nt_GetProcAddress(Win32uMod, "NtGdiHfontCreate");
-        if (!NtGdiGetGlyphOutline)
+        if (!NtGdiHfontCreate)
             return STATUS_NOT_FOUND;
     }
     else

--- a/src/Core/LocaleEmulator/Hooks/Kernel32Hook.cpp
+++ b/src/Core/LocaleEmulator/Hooks/Kernel32Hook.cpp
@@ -217,6 +217,8 @@ NTSTATUS LeSetupAnsiOemCodeHashNodes() {
     WriteLog(L"SetupAnsiOemCodeHashNodes: %p\n", the_func);
 
     the_func();
+
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS LeGlobalData::HackAnsiOemCodeHashNodes() {

--- a/src/Core/LocaleEmulator/LocaleEmulator.h
+++ b/src/Core/LocaleEmulator/LocaleEmulator.h
@@ -259,7 +259,7 @@ LeOpenDirectoryObject(
     UNICODE_STRING               DirectoryName;
 
     DirectoryName.Buffer          = DirectoryNameBuffer;
-    DirectoryName.Length          = wcslen(DirectoryNameBuffer) * sizeof(WCHAR);
+    DirectoryName.Length          = (USHORT)(wcslen(DirectoryNameBuffer) * sizeof(WCHAR));
     DirectoryName.MaximumLength   = DirectoryName.Length;
 
     InitializeObjectAttributes(&ObjectAttributes, &DirectoryName, OBJ_CASE_INSENSITIVE, RootHandle, nullptr);

--- a/src/Core/LocaleEmulator/LocaleEmulator.vcxproj
+++ b/src/Core/LocaleEmulator/LocaleEmulator.vcxproj
@@ -110,8 +110,7 @@
       <ImportLibrary>.\Release\LocaleEmulator.lib</ImportLibrary>
       <DelayLoadDLLs>USER32.dll;DBGHELP.dll;GDI32.dll;KERNEL32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalDependencies>MyLib.lib;undoc_ntdll.lib;undoc_k32.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <AdditionalOptions>/ignore:4254</AdditionalOptions>
       <OptimizeReferences>true</OptimizeReferences>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/LEGUI/App.xaml.cs
+++ b/src/LEGUI/App.xaml.cs
@@ -74,7 +74,7 @@ public partial class App : Application
                                                                      "LEGUI.exe"),
                                                         e.Args);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     MessageBox.Show("LEGUI requires administrator privilege to write to the current directory.",
                                     "Locale Emulator",

--- a/src/LEProc/LoaderWrapper.cs
+++ b/src/LEProc/LoaderWrapper.cs
@@ -378,6 +378,8 @@ internal class LoaderWrapper
         }
     }
 
+#pragma warning disable CS0649 // Fields populated by Marshal.PtrToStructure in BytesToStruct<T>
+    [StructLayout(LayoutKind.Sequential)]
     private struct _REG_TZI_FORMAT
     {
         internal int Bias;
@@ -386,6 +388,7 @@ internal class LoaderWrapper
         internal _SYSTEMTIME StandardDate;
         internal _SYSTEMTIME DaylightDate;
     }
+#pragma warning restore CS0649
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct _SYSTEMTIME

--- a/src/LEProc/Program.cs
+++ b/src/LEProc/Program.cs
@@ -292,16 +292,17 @@ internal static class Program
 
     internal static int GetCharsetFromANSICodepage(int ansicp)
     {
+#pragma warning disable CS0219 // Charset constants kept for completeness per Win32 WINGDI.H
         const int ANSI_CHARSET = 0;
-        const int DEFAULT_CHARSET = 1;
-        const int SYMBOL_CHARSET = 2;
+        const int DEFAULT_CHARSET = 1;   // Not mapped: meta-value "use system default"
+        const int SYMBOL_CHARSET = 2;    // Not mapped: for symbol fonts, not a text encoding
         const int SHIFTJIS_CHARSET = 128;
         const int HANGEUL_CHARSET = 129;
-        const int HANGUL_CHARSET = 129;
+        const int HANGUL_CHARSET = 129;  // Not mapped: spelling variant of HANGEUL_CHARSET
         const int GB2312_CHARSET = 134;
         const int CHINESEBIG5_CHARSET = 136;
-        const int OEM_CHARSET = 255;
-        const int JOHAB_CHARSET = 130;
+        const int OEM_CHARSET = 255;     // Not mapped: meta-value "use OEM default"
+        const int JOHAB_CHARSET = 130;   // Not mapped: codepage 1361 is not a standard ANSI codepage
         const int HEBREW_CHARSET = 177;
         const int ARABIC_CHARSET = 178;
         const int GREEK_CHARSET = 161;
@@ -310,8 +311,9 @@ internal static class Program
         const int THAI_CHARSET = 222;
         const int EASTEUROPE_CHARSET = 238;
         const int RUSSIAN_CHARSET = 204;
-        const int MAC_CHARSET = 77;
+        const int MAC_CHARSET = 77;      // Not mapped: Mac codepages not in CultureInfo.TextInfo.ANSICodePage
         const int BALTIC_CHARSET = 186;
+#pragma warning restore CS0219
 
         var charset = ANSI_CHARSET;
 


### PR DESCRIPTION
## 摘要

消除所有 source-level 和 linker-level build warnings，達成 .NET zero-warning + C++ zero source/linker warning build。

## 問題討論

### 為什麼不移除未使用的 charset 常數？

原方案是移除 6 個未使用的 charset 常數（CS0219），但保留它們更好——保持 Win32 WINGDI.H 的完整參照集。改用 `#pragma warning disable CS0219` + 行尾註解說明各常數為何沒有對應的 ANSI codepage mapping。

### C4551 (`Gdi32Hook.cpp:836`) 不只是 warning，是 logic bug

`if (!NtGdiGetGlyphOutline)` 檢查了錯誤的 identifier。`NtGdiGetGlyphOutline` 是 `ml.h` 中的 inline function，指標永遠非 null，所以 null-check 是死程式碼。對照 else 分支（line 842）正確寫 `if (NtGdiHfontCreate == nullptr)` 確認是筆誤。

### C4715 (`Kernel32Hook.cpp:220`) 不只是 warning，是 undefined behavior

`LeSetupAnsiOemCodeHashNodes()` 回傳 `NTSTATUS` 但 happy path 結尾缺少 `return`。C++ 標準規定 non-void 函式走到結尾不 return 是 UB。加 `return STATUS_SUCCESS;`。

### C4389 的修法：cast 而非 pragma suppress

`std::find` 比較 `ULONG_PTR[]` 和 `LONG` 產生 signed/unsigned mismatch。不管哪個版本的 STL，`==` 兩邊型別不同就會 warn。改在呼叫端 cast `(ULONG_PTR)Object` 消除型別不一致，而非用 pragma 遮蓋。Cast 安全性由 line 165 的 bounds check 保證（負值會 break 出迴圈，到 line 175 時 Object 保證非負）。

### LNK4254 的修法：vcxproj 而非 source pragma

原方案用 `#pragma comment(linker, "/ignore:4254")`，但實測發現舊版 `_Compilers/` 的 link.exe 不支援 `/ignore:` 作為 pragma directive（產生 LNK4229）。改放在 vcxproj linker `<AdditionalOptions>` 中，command-line 方式有效。

### 延後至 Issue 14 的項目

以下警告皆源自 vcxproj 配置與舊版 `_Compilers/` 工具鏈不一致，屬 Issue 14（移除 `_Compilers` 依賴）的範圍：

- D9002 `/Zc:templateScope-` — 當前 compiler 不支援（已更新 Issue 14 comment）
- D9002 `/diagnostics:column`, `/external:W4` — MSBuild v18 自動注入
- D9025 `/GS` override + vcxproj 重複 flags（已更新 Issue 14 comment）

## 變更清單

### Commit 1: .NET warnings (12 unique)

| Warning | 檔案 | 修法 |
|---------|------|------|
| CS0219 ×6 | `Program.cs` | 保留常數 + 行尾註解 + `#pragma warning disable/restore` |
| CS0168 ×1 | `App.xaml.cs` | `catch (Exception ex)` → `catch (Exception)` |
| CS0649 ×5 | `LoaderWrapper.cs` | 加 `[StructLayout]` + `#pragma warning disable/restore` |

### Commit 2: C++ warnings + bug fixes

| Warning | 檔案 | 修法 |
|---------|------|------|
| C4267 ×8 TU | `LocaleEmulator.h:262` | 顯式 `(USHORT)` cast |
| C4551 ×1 | `Gdi32Hook.cpp:836` | **Bug fix**: `NtGdiGetGlyphOutline` → `NtGdiHfontCreate` |
| C4715 ×1 | `Kernel32Hook.cpp:220` | **UB fix**: 加 `return STATUS_SUCCESS;` |
| C4389 ×1 | `Gdi32Hook.cpp:175` | Cast `Object` to `ULONG_PTR` |
| LNK4254 ×2 | `LocaleEmulator.vcxproj`, `LoaderDll.vcxproj` | Linker `/ignore:4254`（故意的 section merge） |

## 驗證

- [x] .NET clean build: 0 warnings（LEProc + LEGUI + LECommonLibrary）
- [x] C++ rebuild: 0 source/linker warnings（僅剩 D9002/D9025 延後至 Issue 14）
- [x] .NET tests: 74 pass（23 + 14 + 37）
- [x] Smoke test: 5/5 pass（ja-JP, zh-TW, zh-CN, ko-KR, en-US）

Closes ooxxTaiwan/Locale-Emulator-J#23