### PR TITLE
feat(LEGUI): Shell Extension 安裝 UI 與 TabControl 版面重構

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ _tmp_*/
 .claude/settings.local.json
 .claude/worktrees/
 CLAUDE.local.md
+.superpowers/
+.playwright-mcp/
 
 ## ----- 例外：Core 解壓後的二進位檔需要追蹤 -----
 ## _Compilers、_Libs、_WDK 中的 .lib / .exe 等二進位檔

--- a/docs/superpowers/plans/2026-04-18-legui-shell-extension-ui-and-layout-refactor.md
+++ b/docs/superpowers/plans/2026-04-18-legui-shell-extension-ui-and-layout-refactor.md
@@ -1,0 +1,1671 @@
+# LEGUI Shell Extension UI and Layout Refactor - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 LEGUI 加入 Shell Extension 安裝/解除安裝 UI，同時將 `GlobalConfig` / `AppConfig` 兩個主視窗改用 TabControl、抽出共用 `ProfileEditorControl`、修復既有版面問題。
+
+**Architecture:** 兩個主視窗皆採 `TabControl`（Profile + About 共用，Shell Extension 僅 GlobalConfig 有）。共用 `ProfileEditorControl` UserControl 消除 95% 重複版面。Shell Extension 安裝 All Users 時以子 process（`LEGUI.exe --shell-ext ...`）提權，不影響主 UI 狀態。
+
+**Tech Stack:** C# 14, .NET 10 (net10.0-windows), WPF, xUnit + NSubstitute + **Xunit.StaFact**（新增，WPF UserControl 測試需 STA thread）。
+
+**Spec reference:** `docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md`
+
+**Issue:** ooxxTaiwan/Locale-Emulator-J#19
+
+---
+
+## Prerequisites
+
+### P1: 建立 worktree
+
+- [ ] **Step 1: 建立獨立 worktree 並切到 feature branch**
+
+```bash
+cd E:/Code/Locale-Emulator
+git worktree add -b feature/issue-19-shell-ext-ui ../Locale-Emulator-issue-19 master
+cd ../Locale-Emulator-issue-19
+```
+
+- [ ] **Step 2: 驗證 spec 已存在於 worktree**
+
+```bash
+ls docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md
+ls docs/superpowers/plans/2026-04-18-legui-shell-extension-ui-and-layout-refactor.md
+```
+
+Expected: 兩個檔案都存在。
+
+### P2: 新增 Xunit.StaFact 套件
+
+**Files:**
+- Modify: `tests/LEGUI.Tests/LEGUI.Tests.csproj`
+
+- [ ] **Step 1: 在 `LEGUI.Tests.csproj` 的 `<ItemGroup>` 加入**
+
+```xml
+<PackageReference Include="Xunit.StaFact" Version="1.*" />
+```
+
+- [ ] **Step 2: Restore 套件**
+
+```bash
+dotnet restore tests/LEGUI.Tests/LEGUI.Tests.csproj
+```
+
+Expected: restore 成功，無錯誤。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add tests/LEGUI.Tests/LEGUI.Tests.csproj
+git commit -m "test: add Xunit.StaFact for WPF UserControl tests"
+```
+
+---
+
+## Phase 1: ProfileEditorControl UserControl
+
+### Task 1.1: 建立 ProfileEditorControl 骨架與 LoadProfile/ReadProfile 測試
+
+**Files:**
+- Create: `src/LEGUI/ProfileEditorControl.xaml`
+- Create: `src/LEGUI/ProfileEditorControl.xaml.cs`
+- Create: `tests/LEGUI.Tests/ProfileEditorControlTests.cs`
+
+- [ ] **Step 1: 撰寫失敗的測試（load / read 往返）**
+
+`tests/LEGUI.Tests/ProfileEditorControlTests.cs`:
+
+```csharp
+using LECommonLibrary;
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ProfileEditorControlTests
+{
+    private static LEProfile SampleProfile() => new LEProfile(
+        "TestProfile", "{00000000-0000-0000-0000-000000000001}",
+        showInMainMenu: true, parameter: "",
+        location: "ja-JP", timezone: "Tokyo Standard Time",
+        runAsAdmin: false, redirectRegistry: true,
+        isAdvancedRedirection: false, runWithSuspend: false);
+
+    [WpfFact]
+    public void LoadThenRead_RoundTripsAllFields()
+    {
+        var ctrl = new ProfileEditorControl();
+        var original = SampleProfile();
+
+        ctrl.LoadProfile(original);
+        var result = ctrl.ReadProfile(original);
+
+        Assert.Equal(original.Location, result.Location);
+        Assert.Equal(original.Timezone, result.Timezone);
+        Assert.Equal(original.RunAsAdmin, result.RunAsAdmin);
+        Assert.Equal(original.RedirectRegistry, result.RedirectRegistry);
+        Assert.Equal(original.IsAdvancedRedirection, result.IsAdvancedRedirection);
+        Assert.Equal(original.RunWithSuspend, result.RunWithSuspend);
+        Assert.Equal(original.ShowInMainMenu, result.ShowInMainMenu);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.Guid, result.Guid);
+        Assert.Equal(original.Parameter, result.Parameter);
+    }
+}
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ProfileEditorControlTests
+```
+
+Expected: FAIL（`ProfileEditorControl` 類別不存在）
+
+- [ ] **Step 3: 建立最小實作（含 XAML）**
+
+`src/LEGUI/ProfileEditorControl.xaml`:
+
+```xml
+<UserControl x:Class="LEGUI.ProfileEditorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid TextElement.FontFamily="{DynamicResource UIFont}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <GroupBox Grid.Row="0" Header="{DynamicResource LocationSettings}" Margin="4,2">
+            <ComboBox x:Name="cbLocation" Margin="4" />
+        </GroupBox>
+        <GroupBox Grid.Row="1" Header="{DynamicResource TimezoneSettings}" Margin="4,2">
+            <ComboBox x:Name="cbTimezone" Margin="4" />
+        </GroupBox>
+        <GroupBox Grid.Row="2" Header="{DynamicResource DebugOptions}" Margin="4,2">
+            <StackPanel Margin="4">
+                <CheckBox x:Name="cbStartAsAdmin" Content="{DynamicResource AsAdmin}" Margin="0,2" />
+                <CheckBox x:Name="cbRedirectRegistry" Content="{DynamicResource RedirectRegistry}" Margin="0,2" />
+                <CheckBox x:Name="cbIsAdvancedRedirection" Content="{DynamicResource IsAdvancedRedirection}" Margin="0,2" />
+                <CheckBox x:Name="cbStartAsSuspend" Content="{DynamicResource WithCREATESUSPENDED}" Margin="0,2" />
+            </StackPanel>
+        </GroupBox>
+        <GroupBox x:Name="displayGroup" Grid.Row="3" Header="{DynamicResource Display}" Margin="4,2">
+            <CheckBox x:Name="cbShowInMainMenu" Content="{DynamicResource ShowInMainMenu}" Margin="4" />
+        </GroupBox>
+    </Grid>
+</UserControl>
+```
+
+`src/LEGUI/ProfileEditorControl.xaml.cs`:
+
+```csharp
+#nullable disable
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using LECommonLibrary;
+
+namespace LEGUI;
+
+public partial class ProfileEditorControl : UserControl
+{
+    private readonly List<CultureInfo> _cultureInfos;
+    private readonly List<TimeZoneInfo> _timezones;
+
+    public static readonly DependencyProperty ShowDisplayOptionsProperty =
+        DependencyProperty.Register(
+            nameof(ShowDisplayOptions),
+            typeof(bool),
+            typeof(ProfileEditorControl),
+            new PropertyMetadata(true, OnShowDisplayOptionsChanged));
+
+    public bool ShowDisplayOptions
+    {
+        get => (bool)GetValue(ShowDisplayOptionsProperty);
+        set => SetValue(ShowDisplayOptionsProperty, value);
+    }
+
+    public ProfileEditorControl()
+    {
+        InitializeComponent();
+
+        _cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .OrderBy(i => i.DisplayName).ToList();
+        cbLocation.ItemsSource = _cultureInfos.Select(c => c.DisplayName);
+
+        _timezones = TimeZoneInfo.GetSystemTimeZones().ToList();
+        cbTimezone.ItemsSource = _timezones.Select(t => t.DisplayName);
+    }
+
+    public void LoadProfile(LEProfile source)
+    {
+        cbLocation.SelectedIndex = _cultureInfos.FindIndex(ci => ci.Name == source.Location);
+        cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == source.Timezone);
+        cbStartAsAdmin.IsChecked = source.RunAsAdmin;
+        cbRedirectRegistry.IsChecked = source.RedirectRegistry;
+        cbIsAdvancedRedirection.IsChecked = source.IsAdvancedRedirection;
+        cbStartAsSuspend.IsChecked = source.RunWithSuspend;
+        cbShowInMainMenu.IsChecked = source.ShowInMainMenu;
+    }
+
+    public LEProfile ReadProfile(LEProfile template)
+    {
+        var locationIdx = cbLocation.SelectedIndex;
+        var timezoneIdx = cbTimezone.SelectedIndex;
+        return new LEProfile(
+            template.Name,
+            template.Guid,
+            ShowDisplayOptions ? cbShowInMainMenu.IsChecked == true : template.ShowInMainMenu,
+            template.Parameter,
+            locationIdx >= 0 ? _cultureInfos[locationIdx].Name : template.Location,
+            timezoneIdx >= 0 ? _timezones[timezoneIdx].Id : template.Timezone,
+            cbStartAsAdmin.IsChecked == true,
+            cbRedirectRegistry.IsChecked == true,
+            cbIsAdvancedRedirection.IsChecked == true,
+            cbStartAsSuspend.IsChecked == true);
+    }
+
+    private static void OnShowDisplayOptionsChanged(
+        DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctrl = (ProfileEditorControl)d;
+        ctrl.displayGroup.Visibility = (bool)e.NewValue ? Visibility.Visible : Visibility.Collapsed;
+    }
+}
+```
+
+- [ ] **Step 4: 在 `DefaultLanguage.xaml` 加入 `Display` i18n key**
+
+Modify `src/LEGUI/Lang/DefaultLanguage.xaml`，加入：
+```xml
+<system:String x:Key="Display">Display</system:String>
+```
+
+- [ ] **Step 5: 執行測試確認通過**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ProfileEditorControlTests
+```
+
+Expected: PASS（1 個測試通過）
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/LEGUI/ProfileEditorControl.xaml src/LEGUI/ProfileEditorControl.xaml.cs src/LEGUI/Lang/DefaultLanguage.xaml tests/LEGUI.Tests/ProfileEditorControlTests.cs
+git commit -m "feat(LEGUI): add ProfileEditorControl UserControl with Load/Read round-trip"
+```
+
+---
+
+### Task 1.2: ShowDisplayOptions 隱藏測試
+
+**Files:**
+- Modify: `tests/LEGUI.Tests/ProfileEditorControlTests.cs`
+
+- [ ] **Step 1: 加入測試**
+
+```csharp
+[WpfFact]
+public void ShowDisplayOptionsFalse_HidesDisplayGroup()
+{
+    var ctrl = new ProfileEditorControl();
+    ctrl.ShowDisplayOptions = false;
+
+    Assert.Equal(System.Windows.Visibility.Collapsed, ctrl.displayGroup.Visibility);
+}
+
+[WpfFact]
+public void ShowDisplayOptionsFalse_ReadProfilePreservesShowInMainMenuFromTemplate()
+{
+    var ctrl = new ProfileEditorControl();
+    ctrl.ShowDisplayOptions = false;
+    var template = SampleProfile(); // ShowInMainMenu=true
+    ctrl.LoadProfile(template);
+
+    // UI 的 cbShowInMainMenu 若被 UI 改了也不應影響 ReadProfile
+    ctrl.cbShowInMainMenu.IsChecked = false;
+    var result = ctrl.ReadProfile(template);
+
+    Assert.True(result.ShowInMainMenu); // 沿用 template
+}
+```
+
+注意：`displayGroup` 和 `cbShowInMainMenu` 需要 `internal` 可存取（LEGUI.csproj 已有 `InternalsVisibleTo`）。將 XAML 的 `x:Name` 生成的欄位預設為 `internal`（WPF 預設即 `internal`，但需確認編譯結果）。
+
+若測試編譯失敗因為欄位是 `private`，在 `ProfileEditorControl.xaml.cs` 明確宣告：
+
+```csharp
+internal GroupBox displayGroup => (GroupBox)FindName("displayGroup");
+internal CheckBox cbShowInMainMenu => (CheckBox)FindName("cbShowInMainMenu");
+```
+
+- [ ] **Step 2: 執行測試確認通過**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ProfileEditorControlTests
+```
+
+Expected: 3 個測試通過
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add tests/LEGUI.Tests/ProfileEditorControlTests.cs src/LEGUI/ProfileEditorControl.xaml.cs
+git commit -m "test(LEGUI): cover ShowDisplayOptions visibility and template preservation"
+```
+
+---
+
+### Task 1.3: 加入 Tooltips 與修錯字
+
+**Files:**
+- Modify: `src/LEGUI/Lang/DefaultLanguage.xaml`
+- Modify: `src/LEGUI/ProfileEditorControl.xaml`
+
+- [ ] **Step 1: 加入 tooltip i18n keys 與修正 `CREATE__SUSPENDED` 錯字**
+
+Modify `src/LEGUI/Lang/DefaultLanguage.xaml`，將既有 `WithCREATESUSPENDED` 的**值**從 `Create process with CREATE__SUSPENDED` 改為 `Create process with CREATE_SUSPENDED`（單底線），並新增 tooltip key：
+
+```xml
+<system:String x:Key="WithCREATESUSPENDED">Create process with CREATE_SUSPENDED</system:String>
+<system:String x:Key="AsAdminTip">Launch the target process with elevated privileges. Required for some games.</system:String>
+<system:String x:Key="RedirectRegistryTip">Intercept Registry reads for locale-related keys, returning the emulated locale instead of the system's.</system:String>
+<system:String x:Key="IsAdvancedRedirectionTip">Also redirect Registry keys that control system UI language, affecting some apps that query via MUI_LANGUAGE_NAME.</system:String>
+<system:String x:Key="WithCREATESUSPENDEDTip">Create the target process in suspended state (advanced debugging option).</system:String>
+<system:String x:Key="ShowInMainMenuTip">Display this profile directly in the right-click menu root instead of under a submenu.</system:String>
+```
+
+- [ ] **Step 2: 在 `ProfileEditorControl.xaml` 的 CheckBox 加 `ToolTip`**
+
+修改 `ProfileEditorControl.xaml`，每個 CheckBox 加對應 tooltip：
+
+```xml
+<CheckBox x:Name="cbStartAsAdmin" Content="{DynamicResource AsAdmin}"
+          ToolTip="{DynamicResource AsAdminTip}" Margin="0,2" />
+<CheckBox x:Name="cbRedirectRegistry" Content="{DynamicResource RedirectRegistry}"
+          ToolTip="{DynamicResource RedirectRegistryTip}" Margin="0,2" />
+<CheckBox x:Name="cbIsAdvancedRedirection" Content="{DynamicResource IsAdvancedRedirection}"
+          ToolTip="{DynamicResource IsAdvancedRedirectionTip}" Margin="0,2" />
+<CheckBox x:Name="cbStartAsSuspend" Content="{DynamicResource WithCREATESUSPENDED}"
+          ToolTip="{DynamicResource WithCREATESUSPENDEDTip}" Margin="0,2" />
+```
+
+以及 displayGroup 內的 cbShowInMainMenu：
+```xml
+<CheckBox x:Name="cbShowInMainMenu" Content="{DynamicResource ShowInMainMenu}"
+          ToolTip="{DynamicResource ShowInMainMenuTip}" Margin="4" />
+```
+
+- [ ] **Step 3: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功，0 錯誤。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/LEGUI/Lang/DefaultLanguage.xaml src/LEGUI/ProfileEditorControl.xaml
+git commit -m "feat(LEGUI): add tooltips to advanced options checkboxes, fix CREATE_SUSPENDED typo"
+```
+
+---
+
+## Phase 2: GlobalConfig TabControl 重構
+
+### Task 2.1: 重構 GlobalConfig.xaml 採用 TabControl
+
+**Files:**
+- Modify: `src/LEGUI/GlobalConfig.xaml`
+- Modify: `src/LEGUI/GlobalConfig.xaml.cs`
+- Modify: `src/LEGUI/Lang/DefaultLanguage.xaml`
+
+- [ ] **Step 1: 加入新的 i18n keys**
+
+Modify `src/LEGUI/Lang/DefaultLanguage.xaml`，加入：
+```xml
+<system:String x:Key="TabProfile">Profile</system:String>
+<system:String x:Key="TabShellExtension">Shell Extension</system:String>
+<system:String x:Key="TabAbout">About</system:String>
+<system:String x:Key="SavedStatus">Saved</system:String>
+```
+
+- [ ] **Step 2: 以 TabControl 改寫 `GlobalConfig.xaml`**
+
+覆寫全檔為：
+
+```xml
+<Window x:Class="LEGUI.GlobalConfig"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:legui="clr-namespace:LEGUI"
+        Title="LEGUI GLOBAL" SizeToContent="Height" MinWidth="420" Width="420"
+        WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
+    <DockPanel TextElement.FontFamily="{DynamicResource UIFont}">
+        <StatusBar x:Name="statusBar" DockPanel.Dock="Bottom" Height="22">
+            <StatusBarItem><TextBlock x:Name="statusText" /></StatusBarItem>
+        </StatusBar>
+        <TabControl Margin="4" MinHeight="380">
+            <TabItem Header="{DynamicResource TabProfile}">
+                <DockPanel Margin="4">
+                    <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <ComboBox x:Name="cbGlobalProfiles" Grid.Row="0" Grid.ColumnSpan="3"
+                                  VerticalContentAlignment="Center" Margin="3,3,3,4"
+                                  SelectionChanged="cbGlobalProfiles_SelectionChanged" />
+                        <Button x:Name="bSaveGlobalSetting" Grid.Row="1" Grid.Column="0"
+                                Content="{DynamicResource Save}" Margin="3,0,3,5"
+                                Click="bSaveGlobalSetting_Click" />
+                        <Button x:Name="bSaveGlobalSettingAs" Grid.Row="1" Grid.Column="1"
+                                Content="{DynamicResource SaveAs}" Margin="3,0,3,5"
+                                Click="bSaveGlobalSettingAs_Click" />
+                        <Button x:Name="bDeleteGlobalSetting" Grid.Row="1" Grid.Column="2"
+                                Content="{DynamicResource Delete}" Margin="3,0,3,5"
+                                Click="bDeleteGlobalSetting_Click" />
+                    </Grid>
+                    <legui:ProfileEditorControl x:Name="profileEditor" />
+                </DockPanel>
+            </TabItem>
+            <TabItem Header="{DynamicResource TabShellExtension}">
+                <!-- 暫時為空，Task 4 會填入 ShellExtensionPanel -->
+                <Grid />
+            </TabItem>
+            <TabItem Header="{DynamicResource TabAbout}">
+                <!-- 暫時為空，Task 6 會填入 AboutPanel -->
+                <Grid />
+            </TabItem>
+        </TabControl>
+    </DockPanel>
+</Window>
+```
+
+- [ ] **Step 3: 改寫 `GlobalConfig.xaml.cs` 使用 ProfileEditorControl**
+
+```csharp
+#nullable disable
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using LECommonLibrary;
+
+namespace LEGUI;
+
+public partial class GlobalConfig
+{
+    private readonly List<LEProfile> _profiles;
+    private readonly DispatcherTimer _statusClearTimer;
+
+    public GlobalConfig()
+    {
+        InitializeComponent();
+
+        _profiles = LEConfig.GetProfiles().ToList();
+        cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
+
+        _statusClearTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+        _statusClearTimer.Tick += (_, _) =>
+        {
+            statusText.Text = string.Empty;
+            _statusClearTimer.Stop();
+        };
+    }
+
+    private void ShowSavedStatus()
+    {
+        statusText.Text = I18n.GetString("SavedStatus");
+        _statusClearTimer.Stop();
+        _statusClearTimer.Start();
+    }
+
+    private void bSaveGlobalSetting_Click(object sender, RoutedEventArgs e)
+    {
+        if (cbGlobalProfiles.Items.Count == 0)
+            return;
+
+        var idx = cbGlobalProfiles.SelectedIndex;
+        _profiles[idx] = profileEditor.ReadProfile(_profiles[idx]);
+        LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
+        ShowSavedStatus();
+    }
+
+    private void cbGlobalProfiles_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        bDeleteGlobalSetting.IsEnabled = cbGlobalProfiles.Items.Count != 0;
+        bSaveGlobalSetting.IsEnabled = cbGlobalProfiles.Items.Count != 0;
+
+        if (cbGlobalProfiles.SelectedIndex == -1)
+            return;
+
+        profileEditor.LoadProfile(_profiles[cbGlobalProfiles.SelectedIndex]);
+    }
+
+    private void bSaveGlobalSettingAs_Click(object sender, RoutedEventArgs e)
+    {
+        var ib = new InputBox
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Instruction = I18n.GetString("SaveAsInstruction"),
+            OkText = I18n.GetString("Save"),
+            CancelText = I18n.GetString("Cancel")
+        };
+
+        if (ib.ShowDialog() == true && !string.IsNullOrEmpty(ib.Text))
+        {
+            SaveProfileAs(ib.Text);
+            cbGlobalProfiles.SelectedIndex = _profiles.Count - 1;
+            ShowSavedStatus();
+        }
+    }
+
+    private void SaveProfileAs(string name)
+    {
+        // 以當前 UI 值建立 profile，Name 用新名稱、Guid 新生
+        var template = cbGlobalProfiles.SelectedIndex >= 0
+            ? _profiles[cbGlobalProfiles.SelectedIndex]
+            : new LEProfile(true);
+        template.Name = name;
+        template.Guid = Guid.NewGuid().ToString();
+        var created = profileEditor.ReadProfile(template);
+
+        _profiles.Add(created);
+        LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
+
+        cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
+    }
+
+    private void bDeleteGlobalSetting_Click(object sender, RoutedEventArgs e)
+    {
+        if (cbGlobalProfiles.SelectedIndex == -1)
+            return;
+
+        if (MessageBoxResult.No == MessageBox.Show(
+            I18n.GetString("ConfirmDel"),
+            "Locale Emulator",
+            MessageBoxButton.YesNo))
+            return;
+
+        _profiles.RemoveAt(cbGlobalProfiles.SelectedIndex);
+        LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
+        cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
+        cbGlobalProfiles.SelectedIndex = 0;
+    }
+}
+```
+
+重點變更：
+- 移除 `CultureInfo`/`TimeZoneInfo` 清單（移至 ProfileEditorControl 內部）
+- 移除 BlurEffect（`ShowDialog()` modal 已足夠）
+- `MessageBox.Show` 第二參數從 `""` 改為 `"Locale Emulator"`
+- `IsChecked != null && (bool)IsChecked` 全部已在 ReadProfile 內改為 `== true`
+- 新增 `ShowSavedStatus()` 透過 DispatcherTimer 3 秒後清空
+
+- [ ] **Step 4: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/LEGUI/GlobalConfig.xaml src/LEGUI/GlobalConfig.xaml.cs src/LEGUI/Lang/DefaultLanguage.xaml
+git commit -m "refactor(LEGUI): GlobalConfig adopts TabControl and shared ProfileEditorControl"
+```
+
+---
+
+## Phase 3: AppConfig TabControl 重構
+
+### Task 3.1: 重構 AppConfig.xaml 採用 TabControl（ShowDisplayOptions=False）
+
+**Files:**
+- Modify: `src/LEGUI/AppConfig.xaml`
+- Modify: `src/LEGUI/AppConfig.xaml.cs`
+
+**說明**：既有 `bSaveAppSetting_Click` / `bShortcut_Click` 都呼叫 `RunAndShutdown()`（儲存後立即啟動目標程式並關閉 LEGUI），所以 AppConfig 不需要 StatusBar「Saved」回饋（App 會立刻關閉）。這與 GlobalConfig 行為不同。
+
+- [ ] **Step 1: 以 TabControl 改寫 `AppConfig.xaml`（Profile + About，無 StatusBar）**
+
+```xml
+<Window x:Class="LEGUI.AppConfig"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:legui="clr-namespace:LEGUI"
+        Title="LEGUI - " SizeToContent="Height" MinWidth="420" Width="420"
+        WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
+    <Grid TextElement.FontFamily="{DynamicResource UIFont}">
+        <TabControl Margin="4" MinHeight="340">
+            <TabItem Header="{DynamicResource TabProfile}">
+                <DockPanel Margin="4">
+                    <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <legui:MaskedTextBox x:Name="tbAppParameter" Grid.Row="0" Grid.ColumnSpan="3"
+                                             MaskText="{StaticResource EnterArgument}"
+                                             VerticalContentAlignment="Center" Margin="3,3,3,4" />
+                        <Button x:Name="bSaveAppSetting" Grid.Row="1" Grid.Column="0"
+                                Content="{DynamicResource Save}" Margin="3,0,3,5"
+                                Click="bSaveAppSetting_Click" />
+                        <Button x:Name="bShortcut" Grid.Row="1" Grid.Column="1"
+                                Content="{DynamicResource Shortcut}" Margin="3,0,3,5"
+                                Click="bShortcut_Click" />
+                        <Button x:Name="bDeleteAppSetting" Grid.Row="1" Grid.Column="2"
+                                Content="{DynamicResource Delete}" Margin="3,0,3,5"
+                                Click="bDeleteAppSetting_Click" />
+                    </Grid>
+                    <legui:ProfileEditorControl x:Name="profileEditor" ShowDisplayOptions="False" />
+                </DockPanel>
+            </TabItem>
+            <TabItem Header="{DynamicResource TabAbout}">
+                <!-- 暫時為空，Task 6 會填入 AboutPanel -->
+                <Grid />
+            </TabItem>
+        </TabControl>
+    </Grid>
+</Window>
+```
+
+- [ ] **Step 2: 改寫 `AppConfig.xaml.cs` 使用 ProfileEditorControl**
+
+覆寫全檔：
+
+```csharp
+#nullable disable
+
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices.ComTypes;
+using System.Windows;
+using LECommonLibrary;
+
+namespace LEGUI;
+
+public partial class AppConfig
+{
+    public AppConfig()
+    {
+        InitializeComponent();
+
+        Title += Path.GetFileName(App.StandaloneFilePath).Replace(".le.config", "");
+
+        // 載入既有設定（或使用預設）
+        var configs = LEConfig.GetProfiles(App.StandaloneFilePath);
+        LEProfile initial;
+        if (configs.Length > 0)
+        {
+            initial = configs[0];
+            if (!string.IsNullOrEmpty(initial.Parameter))
+            {
+                tbAppParameter.FontStyle = FontStyles.Normal;
+                tbAppParameter.Text = initial.Parameter;
+            }
+        }
+        else
+        {
+            // 預設 ja-JP / Tokyo
+            initial = new LEProfile(true);
+        }
+
+        profileEditor.LoadProfile(initial);
+    }
+
+    private void SaveSetting()
+    {
+        // 以當前 UI 值建立 profile
+        var template = new LEProfile(
+            Path.GetFileName(App.StandaloneFilePath),
+            Guid.NewGuid().ToString(),
+            false,              // AppConfig 不用 ShowInMainMenu（ShowDisplayOptions=False 會沿用此值）
+            tbAppParameter.Text,
+            "ja-JP",            // 會被 profileEditor.ReadProfile 覆寫
+            "Tokyo Standard Time",
+            false, false, false, false);
+
+        var crt = profileEditor.ReadProfile(template);
+        crt.Parameter = tbAppParameter.Text; // ReadProfile 沿用 template.Parameter，已 OK
+
+        LEConfig.SaveApplicationConfigFile(App.StandaloneFilePath, crt);
+    }
+
+    private void CreateShortcut(string path)
+    {
+        try
+        {
+            var link = (IShellLink)new ShellLink();
+            link.SetPath(Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "LEProc.exe"));
+            link.SetArguments($"-run \"{path}\"");
+            link.SetIconLocation(
+                AssociationReader.GetAssociatedIcon(Path.GetExtension(path)).Replace("%1", path), 0);
+            link.SetDescription($"Run {Path.GetFileName(path)} with Locale Emulator");
+            link.SetWorkingDirectory(Path.GetDirectoryName(path));
+
+            var file = (IPersistFile)link;
+            file.Save(
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
+                    Path.GetFileNameWithoutExtension(path) + ".lnk"),
+                false);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(ex.Message + "\r\n\r\n" + ex.StackTrace, "Locale Emulator");
+        }
+    }
+
+    private void RunAndShutdown()
+    {
+        Process.Start(
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "LEProc.exe"),
+            $"-run \"{App.StandaloneFilePath.Replace(".le.config", "")}\"");
+        Application.Current.Shutdown();
+    }
+
+    private void bSaveAppSetting_Click(object sender, RoutedEventArgs e)
+    {
+        SaveSetting();
+        RunAndShutdown();
+    }
+
+    private void bShortcut_Click(object sender, RoutedEventArgs e)
+    {
+        SaveSetting();
+        CreateShortcut(App.StandaloneFilePath.Replace(".le.config", ""));
+        RunAndShutdown();
+    }
+
+    private void bDeleteAppSetting_Click(object sender, RoutedEventArgs e)
+    {
+        if (MessageBoxResult.No == MessageBox.Show(
+            I18n.GetString("ConfirmDel"),
+            "Locale Emulator",
+            MessageBoxButton.YesNo))
+            return;
+
+        if (File.Exists(App.StandaloneFilePath))
+            File.Delete(App.StandaloneFilePath);
+
+        Application.Current.Shutdown();
+    }
+}
+```
+
+重點變更：
+- `CultureInfo` / `TimeZoneInfo` 清單完全移除（移至 ProfileEditorControl 內部）
+- `SaveSetting` 改用 `profileEditor.ReadProfile(template)` 組 profile
+- 空標題對話框修正為 `"Locale Emulator"`
+- `IsChecked != null && (bool)IsChecked` 全部消失（由 ReadProfile 內部處理）
+- **保留** `RunAndShutdown()` 既有行為（Save 後啟動目標程式）
+
+- [ ] **Step 3: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/LEGUI/AppConfig.xaml src/LEGUI/AppConfig.xaml.cs
+git commit -m "refactor(LEGUI): AppConfig adopts TabControl and shared ProfileEditorControl"
+```
+
+---
+
+## Phase 4: ShellExtensionPanel UserControl
+
+### Task 4.1: 建立 ShellExtensionPanel 骨架（僅 UI + 狀態顯示）
+
+**Files:**
+- Create: `src/LEGUI/ShellExtensionPanel.xaml`
+- Create: `src/LEGUI/ShellExtensionPanel.xaml.cs`
+- Create: `tests/LEGUI.Tests/ShellExtensionPanelTests.cs`
+
+- [ ] **Step 1: 先寫失敗測試（按鈕狀態對應 IsInstalled）**
+
+```csharp
+using NSubstitute;
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ShellExtensionPanelTests
+{
+    [WpfFact]
+    public void RefreshStatus_WhenCurrentUserInstalled_DisablesInstallButton()
+    {
+        var panel = new ShellExtensionPanel();
+        var registrar = Substitute.For<IShellExtensionQuery>();
+        registrar.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser).Returns(true);
+        registrar.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers).Returns(false);
+        registrar.HasOldRegistration().Returns(false);
+
+        panel.SetQuery(registrar);
+        panel.RefreshStatus();
+
+        Assert.False(panel.bInstallCurrentUser.IsEnabled);
+        Assert.True(panel.bUninstallCurrentUser.IsEnabled);
+        Assert.True(panel.bInstallAllUsers.IsEnabled);
+        Assert.False(panel.bUninstallAllUsers.IsEnabled);
+    }
+
+    [WpfFact]
+    public void RefreshStatus_HasOldRegistration_ShowsCleanupSection()
+    {
+        var panel = new ShellExtensionPanel();
+        var registrar = Substitute.For<IShellExtensionQuery>();
+        registrar.HasOldRegistration().Returns(true);
+
+        panel.SetQuery(registrar);
+        panel.RefreshStatus();
+
+        Assert.Equal(System.Windows.Visibility.Visible, panel.cleanupSection.Visibility);
+    }
+}
+```
+
+**抽介面**：為了測試，加入薄介面 `IShellExtensionQuery` 封裝 `ShellExtensionRegistrar` 的查詢方法：
+
+```csharp
+// src/LEGUI/IShellExtensionQuery.cs
+public interface IShellExtensionQuery
+{
+    bool IsInstalled(ShellExtensionRegistrar.InstallMode mode);
+    bool HasOldRegistration();
+}
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ShellExtensionPanelTests
+```
+
+Expected: FAIL（ShellExtensionPanel 不存在）
+
+- [ ] **Step 3: 建立 XAML**
+
+`src/LEGUI/ShellExtensionPanel.xaml`:
+
+```xml
+<UserControl x:Class="LEGUI.ShellExtensionPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="8" TextElement.FontFamily="{DynamicResource UIFont}">
+        <GroupBox Header="Current User" Margin="0,4">
+            <StackPanel Margin="8">
+                <TextBlock>
+                    <Run Text="{DynamicResource InstallStatus}" />
+                    <Run x:Name="tStatusCurrentUser" FontWeight="Bold" />
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button x:Name="bInstallCurrentUser" Content="{DynamicResource InstallCurrentUser}"
+                            MinWidth="120" Margin="0,0,8,0" Click="bInstallCurrentUser_Click" />
+                    <Button x:Name="bUninstallCurrentUser" Content="{DynamicResource Uninstall}"
+                            MinWidth="100" Click="bUninstallCurrentUser_Click" />
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+        <GroupBox Header="All Users 🛡" Margin="0,4">
+            <StackPanel Margin="8">
+                <TextBlock>
+                    <Run Text="{DynamicResource InstallStatus}" />
+                    <Run x:Name="tStatusAllUsers" FontWeight="Bold" />
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button x:Name="bInstallAllUsers" Content="{DynamicResource InstallAllUsers}"
+                            MinWidth="120" Margin="0,0,8,0" Click="bInstallAllUsers_Click" />
+                    <Button x:Name="bUninstallAllUsers" Content="{DynamicResource Uninstall}"
+                            MinWidth="100" Click="bUninstallAllUsers_Click" />
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+        <StackPanel x:Name="cleanupSection" Visibility="Collapsed" Margin="0,8">
+            <TextBlock Text="⚠ Old version residue detected" Foreground="DarkRed" />
+            <Button x:Name="bCleanupOld" Content="Clean up old registration" MinWidth="180"
+                    HorizontalAlignment="Left" Margin="0,4,0,0" Click="bCleanupOld_Click" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>
+```
+
+- [ ] **Step 4: 建立 code-behind（最小實作至測試通過）**
+
+`src/LEGUI/ShellExtensionPanel.xaml.cs`:
+
+```csharp
+#nullable disable
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LEGUI;
+
+public partial class ShellExtensionPanel : UserControl
+{
+    private IShellExtensionQuery _query;
+
+    public ShellExtensionPanel()
+    {
+        InitializeComponent();
+    }
+
+    public void SetQuery(IShellExtensionQuery query) => _query = query;
+
+    public void RefreshStatus()
+    {
+        if (_query == null) return;
+
+        var cuInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser);
+        var auInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+        tStatusCurrentUser.Text = " " + I18n.GetString(cuInstalled ? "Installed" : "NotInstalled");
+        tStatusAllUsers.Text = " " + I18n.GetString(auInstalled ? "Installed" : "NotInstalled");
+
+        bInstallCurrentUser.IsEnabled = !cuInstalled;
+        bUninstallCurrentUser.IsEnabled = cuInstalled;
+        bInstallAllUsers.IsEnabled = !auInstalled;
+        bUninstallAllUsers.IsEnabled = auInstalled;
+
+        cleanupSection.Visibility = _query.HasOldRegistration()
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    // 以下 click handler 先留空，Task 4.2+ 實作
+    private void bInstallCurrentUser_Click(object sender, RoutedEventArgs e) { }
+    private void bUninstallCurrentUser_Click(object sender, RoutedEventArgs e) { }
+    private void bInstallAllUsers_Click(object sender, RoutedEventArgs e) { }
+    private void bUninstallAllUsers_Click(object sender, RoutedEventArgs e) { }
+    private void bCleanupOld_Click(object sender, RoutedEventArgs e) { }
+}
+```
+
+實作 `IShellExtensionQuery` adapter（讓 ShellExtensionRegistrar 能直接當 IShellExtensionQuery 用）：
+
+```csharp
+// 在 ShellExtensionRegistrar.cs 加入 interface 實作
+public sealed class ShellExtensionRegistrar : IShellExtensionQuery
+{
+    // ...既有內容... 既有的 IsInstalled(mode) 和 HasOldRegistration() 簽名已相容
+}
+```
+
+- [ ] **Step 5: 執行測試確認通過**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ShellExtensionPanelTests
+```
+
+Expected: 2 個測試通過
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/LEGUI/ShellExtensionPanel.xaml src/LEGUI/ShellExtensionPanel.xaml.cs src/LEGUI/IShellExtensionQuery.cs src/LEGUI/ShellExtensionRegistrar.cs tests/LEGUI.Tests/ShellExtensionPanelTests.cs
+git commit -m "feat(LEGUI): add ShellExtensionPanel with install status display"
+```
+
+---
+
+### Task 4.2: 接上 Install/Uninstall 按鈕的 in-process 路徑（admin 情境）
+
+**Files:**
+- Modify: `src/LEGUI/ShellExtensionPanel.xaml.cs`
+- Modify: `src/LEGUI/GlobalConfig.xaml`（把 Shell Extension tab 內容改為 ShellExtensionPanel）
+- Modify: `src/LEGUI/GlobalConfig.xaml.cs`（建立 registrar、註入 panel）
+- Modify: `tests/LEGUI.Tests/ShellExtensionPanelTests.cs`
+
+- [ ] **Step 1: 測試：按下 Install，呼叫 registrar.Register**
+
+擴充介面為完整 command：
+
+```csharp
+public interface IShellExtensionCommand : IShellExtensionQuery
+{
+    void Register(ShellExtensionRegistrar.InstallMode mode, string dllPath);
+    void Unregister(ShellExtensionRegistrar.InstallMode mode);
+    void CleanupOldRegistration();
+}
+```
+
+測試：
+
+```csharp
+[WpfFact]
+public void InstallCurrentUser_CallsRegisterWithCurrentUserMode()
+{
+    var panel = new ShellExtensionPanel();
+    var command = Substitute.For<IShellExtensionCommand>();
+    command.IsInstalled(Arg.Any<ShellExtensionRegistrar.InstallMode>()).Returns(false);
+    panel.SetCommand(command, dllPath: @"C:\fake\ShellExtension.dll", isAdmin: true);
+
+    panel.bInstallCurrentUser.RaiseEvent(
+        new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent));
+
+    command.Received().Register(
+        ShellExtensionRegistrar.InstallMode.CurrentUser,
+        @"C:\fake\ShellExtension.dll");
+}
+```
+
+- [ ] **Step 2: 擴充 ShellExtensionPanel 支援 admin in-process 路徑**
+
+```csharp
+public partial class ShellExtensionPanel : UserControl
+{
+    private IShellExtensionCommand _command;
+    private string _dllPath;
+    private bool _isAdmin;
+
+    public void SetCommand(IShellExtensionCommand command, string dllPath, bool isAdmin)
+    {
+        _command = command;
+        _dllPath = dllPath;
+        _isAdmin = isAdmin;
+        SetQuery(command);
+    }
+
+    private void bInstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => HandleInstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+
+    private void bInstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => HandleInstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+    private void bUninstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => HandleUninstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+
+    private void bUninstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => HandleUninstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+    private void bCleanupOld_Click(object sender, RoutedEventArgs e)
+    {
+        // All Users 路徑需要 admin — Task 4.3 會升級為 async 子 process
+        _command.CleanupOldRegistration();
+        RefreshStatus();
+    }
+
+    private void HandleInstall(ShellExtensionRegistrar.InstallMode mode)
+    {
+        // Task 4.3 會把 AllUsers 分支改為 async 子 process
+        _command.Register(mode, _dllPath);
+        RefreshStatus();
+        MessageBox.Show(I18n.GetString("InstallSuccess"), "Locale Emulator");
+    }
+
+    private void HandleUninstall(ShellExtensionRegistrar.InstallMode mode)
+    {
+        _command.Unregister(mode);
+        RefreshStatus();
+        MessageBox.Show(I18n.GetString("UninstallSuccess"), "Locale Emulator");
+    }
+}
+```
+
+- [ ] **Step 3: 改 `GlobalConfig.xaml` 把 Shell Extension tab 填入 panel**
+
+修改 `GlobalConfig.xaml` 的 `<TabItem Header="{DynamicResource TabShellExtension}">` 內容：
+
+```xml
+<TabItem Header="{DynamicResource TabShellExtension}">
+    <legui:ShellExtensionPanel x:Name="shellExtPanel" />
+</TabItem>
+```
+
+- [ ] **Step 4: 在 `GlobalConfig` 建構子初始化 panel**
+
+```csharp
+public GlobalConfig()
+{
+    InitializeComponent();
+    // ... 既有 profile 初始化
+
+    InitializeShellExtPanel();
+}
+
+private void InitializeShellExtPanel()
+{
+    var basePath = Path.GetDirectoryName(Path.GetDirectoryName(Environment.ProcessPath));
+    if (string.IsNullOrEmpty(basePath))
+        basePath = AppContext.BaseDirectory;
+
+    var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+    var registrar = new ShellExtensionRegistrar(
+        new RegistryOperations(),
+        ShellExtensionConstants.NewClsid);
+
+    shellExtPanel.SetCommand(registrar, dllPath, SystemHelper.IsAdministrator());
+    shellExtPanel.RefreshStatus();
+}
+```
+
+同時在 `ShellExtensionRegistrar.cs` 新增 `IShellExtensionCommand` 的實作（增加 `CleanupOldRegistration` 已存在、`Register`、`Unregister` 簽名相容 interface）。
+
+- [ ] **Step 5: 執行測試**
+
+```bash
+dotnet test tests/LEGUI.Tests/
+```
+
+Expected: 全部通過
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/LEGUI/ShellExtensionPanel.xaml.cs src/LEGUI/IShellExtensionQuery.cs src/LEGUI/ShellExtensionRegistrar.cs src/LEGUI/GlobalConfig.xaml src/LEGUI/GlobalConfig.xaml.cs tests/LEGUI.Tests/ShellExtensionPanelTests.cs
+git commit -m "feat(LEGUI): wire ShellExtensionPanel to GlobalConfig with in-process install path"
+```
+
+---
+
+## Phase 5: CLI 參數 + Sub-process 提權
+
+### Task 5.1: CLI argument parser
+
+**Files:**
+- Create: `src/LEGUI/ShellExtCliCommand.cs`
+- Create: `tests/LEGUI.Tests/ShellExtCliCommandTests.cs`
+
+- [ ] **Step 1: 寫失敗測試**
+
+```csharp
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ShellExtCliCommandTests
+{
+    [Theory]
+    [InlineData(new[] { "--shell-ext", "install", "current-user" },
+                ShellExtCliCommand.Verb.Install,
+                ShellExtensionRegistrar.InstallMode.CurrentUser)]
+    [InlineData(new[] { "--shell-ext", "install", "all-users" },
+                ShellExtCliCommand.Verb.Install,
+                ShellExtensionRegistrar.InstallMode.AllUsers)]
+    [InlineData(new[] { "--shell-ext", "uninstall", "current-user" },
+                ShellExtCliCommand.Verb.Uninstall,
+                ShellExtensionRegistrar.InstallMode.CurrentUser)]
+    public void Parse_ValidArgs_ReturnsParsedCommand(
+        string[] args, ShellExtCliCommand.Verb verb, ShellExtensionRegistrar.InstallMode mode)
+    {
+        var cmd = ShellExtCliCommand.Parse(args);
+        Assert.NotNull(cmd);
+        Assert.Equal(verb, cmd.ActionVerb);
+        Assert.Equal(mode, cmd.Mode);
+    }
+
+    [Fact]
+    public void Parse_CleanupOld_NoModeRequired()
+    {
+        var cmd = ShellExtCliCommand.Parse(new[] { "--shell-ext", "cleanup-old" });
+        Assert.NotNull(cmd);
+        Assert.Equal(ShellExtCliCommand.Verb.CleanupOld, cmd.ActionVerb);
+    }
+
+    [Fact]
+    public void Parse_NonShellExtArgs_ReturnsNull()
+    {
+        Assert.Null(ShellExtCliCommand.Parse(new[] { "game.exe" }));
+        Assert.Null(ShellExtCliCommand.Parse(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Parse_InvalidVerb_ReturnsNull()
+    {
+        Assert.Null(ShellExtCliCommand.Parse(new[] { "--shell-ext", "xyz", "current-user" }));
+    }
+}
+```
+
+- [ ] **Step 2: 執行確認失敗**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ShellExtCliCommandTests
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: 實作**
+
+`src/LEGUI/ShellExtCliCommand.cs`:
+
+```csharp
+#nullable enable
+
+namespace LEGUI;
+
+public sealed class ShellExtCliCommand
+{
+    public enum Verb { Install, Uninstall, CleanupOld }
+
+    public Verb ActionVerb { get; }
+    public ShellExtensionRegistrar.InstallMode Mode { get; }
+
+    private ShellExtCliCommand(Verb verb, ShellExtensionRegistrar.InstallMode mode)
+    {
+        ActionVerb = verb;
+        Mode = mode;
+    }
+
+    public static ShellExtCliCommand? Parse(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "--shell-ext") return null;
+
+        return args[1] switch
+        {
+            "install" when args.Length == 3 && TryParseMode(args[2], out var im)
+                => new ShellExtCliCommand(Verb.Install, im),
+            "uninstall" when args.Length == 3 && TryParseMode(args[2], out var um)
+                => new ShellExtCliCommand(Verb.Uninstall, um),
+            "cleanup-old"
+                => new ShellExtCliCommand(Verb.CleanupOld, ShellExtensionRegistrar.InstallMode.AllUsers),
+            _ => null
+        };
+    }
+
+    private static bool TryParseMode(string s, out ShellExtensionRegistrar.InstallMode mode)
+    {
+        mode = default;
+        if (s == "current-user") { mode = ShellExtensionRegistrar.InstallMode.CurrentUser; return true; }
+        if (s == "all-users")    { mode = ShellExtensionRegistrar.InstallMode.AllUsers; return true; }
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: 測試通過**
+
+```bash
+dotnet test tests/LEGUI.Tests/ --filter ShellExtCliCommandTests
+```
+
+Expected: 5 個測試通過
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/LEGUI/ShellExtCliCommand.cs tests/LEGUI.Tests/ShellExtCliCommandTests.cs
+git commit -m "feat(LEGUI): add ShellExtCliCommand parser for --shell-ext arguments"
+```
+
+---
+
+### Task 5.2: App.xaml.cs 處理 --shell-ext 分支
+
+**Files:**
+- Modify: `src/LEGUI/App.xaml.cs`
+
+- [ ] **Step 1: 在 `App_OnStartup` 最前端加入 CLI 分支**
+
+```csharp
+private void App_OnStartup(object sender, StartupEventArgs e)
+{
+    // 新增：優先處理 --shell-ext CLI，跳過所有 UI 啟動邏輯
+    var cli = ShellExtCliCommand.Parse(e.Args);
+    if (cli != null)
+    {
+        int exitCode = ExecuteShellExtCommand(cli);
+        Current.Shutdown(exitCode);
+        return;
+    }
+
+    // ... 既有邏輯
+}
+
+private int ExecuteShellExtCommand(ShellExtCliCommand cli)
+{
+    try
+    {
+        var basePath = Path.GetDirectoryName(Path.GetDirectoryName(Environment.ProcessPath))
+                       ?? AppContext.BaseDirectory;
+        var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+        var registrar = new ShellExtensionRegistrar(
+            new RegistryOperations(),
+            ShellExtensionConstants.NewClsid);
+
+        switch (cli.ActionVerb)
+        {
+            case ShellExtCliCommand.Verb.Install:
+                registrar.Register(cli.Mode, dllPath);
+                break;
+            case ShellExtCliCommand.Verb.Uninstall:
+                registrar.Unregister(cli.Mode);
+                break;
+            case ShellExtCliCommand.Verb.CleanupOld:
+                registrar.CleanupOldRegistration();
+                break;
+        }
+        return 0;
+    }
+    catch (Exception ex)
+    {
+        // 子 process 不顯示 UI，只回傳錯誤代碼
+        System.Diagnostics.Debug.WriteLine($"--shell-ext failed: {ex}");
+        return 1;
+    }
+}
+```
+
+- [ ] **Step 2: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功。
+
+- [ ] **Step 3: 手動驗證 CLI（以 admin 身分執行）**
+
+```bash
+# 編譯 + 以 admin 執行（需要手動開 Windows Terminal 以管理員身分）
+dotnet build -c Release src/LEGUI/
+# 在管理員 shell 中：
+src/LEGUI/bin/Release/net10.0-windows/LEGUI.exe --shell-ext install current-user
+echo $LASTEXITCODE  # 應為 0
+# 確認 HKCU\Software\Classes\CLSID\{A8B4F5C2-...} 存在
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/LEGUI/App.xaml.cs
+git commit -m "feat(LEGUI): handle --shell-ext CLI branch in App startup"
+```
+
+---
+
+### Task 5.3: Shell Extension 按鈕改走子 process 提權路徑
+
+**Files:**
+- Modify: `src/LEGUI/ShellExtensionPanel.xaml.cs`
+
+- [ ] **Step 1: 改 `HandleInstall` / `HandleUninstall` / `bCleanupOld_Click` 為 async，非 admin 時啟動子 process**
+
+```csharp
+private async void HandleInstall(ShellExtensionRegistrar.InstallMode mode)
+{
+    if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
+    {
+        await RunElevatedAsync("install", "all-users");
+    }
+    else
+    {
+        _command.Register(mode, _dllPath);
+    }
+    RefreshStatus();
+    MessageBox.Show(I18n.GetString("InstallSuccess"), "Locale Emulator");
+}
+
+private async void HandleUninstall(ShellExtensionRegistrar.InstallMode mode)
+{
+    if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
+    {
+        await RunElevatedAsync("uninstall", "all-users");
+    }
+    else
+    {
+        _command.Unregister(mode);
+    }
+    RefreshStatus();
+    MessageBox.Show(I18n.GetString("UninstallSuccess"), "Locale Emulator");
+}
+
+private async void bCleanupOld_Click(object sender, RoutedEventArgs e)
+{
+    if (!_isAdmin)
+    {
+        await RunElevatedAsync("cleanup-old", null);
+    }
+    else
+    {
+        _command.CleanupOldRegistration();
+    }
+    RefreshStatus();
+}
+
+private async Task RunElevatedAsync(string verb, string? scope)
+{
+    SetAllButtonsEnabled(false);
+    try
+    {
+        var args = scope != null ? $"--shell-ext {verb} {scope}" : $"--shell-ext {verb}";
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = Environment.ProcessPath!,
+            Arguments = args,
+            Verb = "runas",
+            UseShellExecute = true
+        };
+        try
+        {
+            using var p = System.Diagnostics.Process.Start(psi);
+            if (p == null) return;
+            await p.WaitForExitAsync();
+            if (p.ExitCode != 0)
+            {
+                MessageBox.Show(
+                    $"Operation failed with exit code {p.ExitCode}.",
+                    "Locale Emulator",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+        }
+        catch (System.ComponentModel.Win32Exception win32) when (win32.NativeErrorCode == 1223)
+        {
+            // 使用者取消 UAC，不顯示錯誤
+        }
+    }
+    finally
+    {
+        SetAllButtonsEnabled(true);
+    }
+}
+
+private void SetAllButtonsEnabled(bool enabled)
+{
+    bInstallCurrentUser.IsEnabled = enabled;
+    bUninstallCurrentUser.IsEnabled = enabled;
+    bInstallAllUsers.IsEnabled = enabled;
+    bUninstallAllUsers.IsEnabled = enabled;
+    bCleanupOld.IsEnabled = enabled;
+}
+```
+
+- [ ] **Step 2: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功。
+
+- [ ] **Step 3: 手動測試（非 admin 身分執行 LEGUI）**
+
+- 開啟 LEGUI（一般使用者權限）
+- 切到 Shell Extension 分頁
+- 點「Install (All Users) 🛡」→ 應彈 UAC 對話框
+- 點「是」→ 子 process 執行，狀態刷新為 "Installed"
+- 點 UAC 的「否」→ 無錯誤訊息，狀態不變
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/LEGUI/ShellExtensionPanel.xaml.cs
+git commit -m "feat(LEGUI): elevate install/uninstall/cleanup via sub-process when not admin"
+```
+
+---
+
+## Phase 6: About Tab + 最後清理
+
+### Task 6.1: 建立 AboutPanel UserControl
+
+**Files:**
+- Create: `src/LEGUI/AboutPanel.xaml`
+- Create: `src/LEGUI/AboutPanel.xaml.cs`
+
+- [ ] **Step 1: 建立 XAML**
+
+`src/LEGUI/AboutPanel.xaml`:
+
+```xml
+<UserControl x:Class="LEGUI.AboutPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="20" TextElement.FontFamily="{DynamicResource UIFont}">
+        <TextBlock FontSize="16" FontWeight="Bold">
+            Locale Emulator (ooxxTaiwan fork)
+        </TextBlock>
+        <TextBlock Margin="0,4,0,0">
+            <Run Text="Version " /><Run x:Name="tVersion" />
+        </TextBlock>
+        <TextBlock Margin="0,16,0,0" FontWeight="Bold">Original project</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/xupefei/Locale-Emulator"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/xupefei/Locale-Emulator
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,8,0,0" FontWeight="Bold">Core (archived 2022-04)</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/xupefei/Locale-Emulator-Core"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/xupefei/Locale-Emulator-Core
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,8,0,0" FontWeight="Bold">This fork</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/ooxxTaiwan/Locale-Emulator-J"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/ooxxTaiwan/Locale-Emulator-J
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,16,0,0">License: LGPL-3.0</TextBlock>
+        <TextBlock>Core portion: LGPL-3.0 / GPL-3.0</TextBlock>
+    </StackPanel>
+</UserControl>
+```
+
+- [ ] **Step 2: 建立 code-behind**
+
+`src/LEGUI/AboutPanel.xaml.cs`:
+
+```csharp
+#nullable disable
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+
+namespace LEGUI;
+
+public partial class AboutPanel : UserControl
+{
+    public AboutPanel()
+    {
+        InitializeComponent();
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        tVersion.Text = version?.ToString(3) ?? "unknown";
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        e.Handled = true;
+    }
+}
+```
+
+- [ ] **Step 3: 在 GlobalConfig 和 AppConfig 把 About TabItem 內容換成 `<legui:AboutPanel />`**
+
+Modify `src/LEGUI/GlobalConfig.xaml`:
+
+```xml
+<TabItem Header="{DynamicResource TabAbout}">
+    <legui:AboutPanel />
+</TabItem>
+```
+
+Modify `src/LEGUI/AppConfig.xaml` 的 About tab 同樣。
+
+- [ ] **Step 4: 建置驗證**
+
+```bash
+dotnet build src/LEGUI/
+```
+
+Expected: 成功。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/LEGUI/AboutPanel.xaml src/LEGUI/AboutPanel.xaml.cs src/LEGUI/GlobalConfig.xaml src/LEGUI/AppConfig.xaml
+git commit -m "feat(LEGUI): add AboutPanel with version, hyperlinks, and license info"
+```
+
+---
+
+### Task 6.2: Smoke test 手動驗證清單
+
+**Files:**
+- 無程式碼修改；僅手動驗證
+
+- [ ] **Step 1: 建置 Release**
+
+```bash
+dotnet build -c Release LocaleEmulator.sln
+# 確保 ShellExtension x86+x64 都編譯成功（vs 需要）
+```
+
+- [ ] **Step 2: 驗證 GlobalConfig 各項**
+
+- [ ] 雙擊 `LEGUI.exe`（一般使用者）→ 視窗開啟、寬度 420、`SizeToContent` 正常
+- [ ] Profile 分頁：選擇 profile、修改欄位、按 Save → 狀態列顯示 "Saved" 3 秒後消失
+- [ ] 錯字修正：CheckBox 顯示 "Create process with CREATE_SUSPENDED"（單底線）
+- [ ] Tooltip：hover 每個 CheckBox 都出現說明文字
+- [ ] Save As：輸入新名稱 → 加入 profile 清單、無 BlurEffect
+- [ ] Delete：對話框標題為 "Locale Emulator"（非空）
+
+- [ ] **Step 3: 驗證 Shell Extension 分頁**
+
+- [ ] Current User 區塊狀態顯示正確（初次 "Not Installed"）
+- [ ] Install (Current User) → 無 UAC、狀態變 "Installed"、Explorer 右鍵 .exe 出現選單
+- [ ] All Users 區塊按 Install → UAC 彈出、點「是」→ 狀態變 "Installed"
+- [ ] Uninstall (Current User) → 狀態變 "Not Installed"
+- [ ] 點 UAC 的「否」→ 無錯誤訊息、狀態不變
+
+- [ ] **Step 4: 驗證 AppConfig 分頁**
+
+- [ ] 拖放 exe 到 `LEGUI.exe` → 開 AppConfig
+- [ ] **確認沒有 Shell Extension 分頁**（只有 Profile + About）
+- [ ] Profile 分頁**沒有 Display GroupBox**（ShowDisplayOptions=False）
+- [ ] Save 運作正常
+
+- [ ] **Step 5: 驗證 About 分頁**
+
+- [ ] 版本號顯示 "3.0.0"
+- [ ] 點超連結開啟系統預設瀏覽器
+
+- [ ] **Step 6: 全部通過後在原 worktree 執行完整測試**
+
+```bash
+dotnet test LocaleEmulator.sln
+```
+
+Expected: 全綠
+
+- [ ] **Step 7: 提交驗證 log**
+
+```bash
+git commit --allow-empty -m "test: complete manual smoke validation for issue #19"
+```
+
+---
+
+## Final Checklist（PR 前）
+
+- [ ] 所有 `dotnet build` + `dotnet test` 通過（無新 warning）
+- [ ] Release 建置 x86 + x64 + managed 皆成功
+- [ ] Smoke test 全部手動驗證通過
+- [ ] Issue #19 原始 checkbox 對應的功能全部完成
+- [ ] PR body 包含：設計討論（spec 的 Section 10）、scope 擴張說明、測試結果
+- [ ] PR 連結 `Closes #19`
+- [ ] 加 issue comment 說明 scope 擴張（DRY + UI 版面重構）
+
+---
+
+## 附註
+
+- **Worktree 清理**：PR merged 後 `git worktree remove ../Locale-Emulator-issue-19 && git branch -d feature/issue-19-shell-ext-ui`
+- **i18n 翻譯**：本 plan 只處理 `DefaultLanguage.xaml`，其他 21 個語言由 Issue #21 接手
+- **SizeToContent 跳動**：如實測分頁切換有視窗跳動，將 TabControl 各分頁包 `<Grid MinHeight="440">` 統一基線

--- a/docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md
@@ -1,0 +1,331 @@
+# 設計文件：LEGUI Shell Extension 安裝 UI 與版面重構
+
+> **Issue**: ooxxTaiwan/Locale-Emulator-J#19
+> **日期**: 2026-04-18
+> **狀態**: 設計確認
+
+---
+
+## 1. 目標與動機
+
+在 LEGUI 中新增 Shell Extension 安裝/解除安裝 UI，取代目前必須手動執行 `regsvr32` 的流程；同時順勢整頓兩個主視窗（`GlobalConfig` / `AppConfig`）95% 重複的版面，抽出共用元件、修掉既有 UX 問題。
+
+**動機**：
+
+- `ShellExtensionRegistrar` 後端已完成（per-user / all-users 雙模式、`RegistryView.Registry64`、舊 CLSID 清理），但前端 UI 從缺，使用者必須手動打 `regsvr32`。
+- `DefaultLanguage.xaml` 已加入 9 個相關 i18n key，但沒有任何 XAML 按鈕連結到後端。
+- `GlobalConfig` 和 `AppConfig` 兩個視窗 95% 版面重複，XAML 和 code-behind 都複製了一份，違反 DRY；擴充新分頁（如 Shell Extension）時必須兩邊同步維護。
+- 既有版面有多處排版/命名/互動問題（變數名與標籤不符、CheckBox 含義不明、空標題對話框、老派 `BlurEffect`、無 Save 成功提示等），使用者體驗欠佳。
+
+**重要定位**：這個任務表面上是「加幾顆按鈕」，實際上是「將設定對話框從扁平單頁結構升級為分頁結構」。分頁結構是後續擴充（ADS 移除、LEUpdater 重設計、Shell Extension 進階選項等）的基礎，不是一次性 UI 修補。
+
+---
+
+## 2. 決策摘要
+
+| 項目 | 決策 | 理由 |
+|------|------|------|
+| **UI scope** | Scope 2：兩視窗都改 TabControl + 抽出 `ProfileEditorControl` UserControl | Scope 1 會讓兩視窗版面分歧；Scope 3 合併視窗偏離 issue 主軸 |
+| **分頁結構** | GlobalConfig：`Profile` / `Shell Extension` / `About`；AppConfig：`Profile` / `About`（不含 Shell Extension） | Shell Extension 是系統級設定，不屬於單檔編輯層級；About 兩視窗共用合理 |
+| **Shell Ext 分頁佈局** | 依模式分組（`Current User` GroupBox + `All Users` GroupBox），舊版清理置於最下方 | 如實反映底層資料模型（HKCU / HKLM 兩個獨立登錄檔位置可並存） |
+| **UAC 升權策略** | 子 process 提權：主 LEGUI 啟動 `LEGUI.exe --shell-ext <verb> <scope>` 並以 `Verb="runas"` 觸發 UAC | 不影響主 UI 狀態，使用者未儲存的 profile 編輯不會遺失 |
+| **Profile 分頁重構** | 最小修改：保留 4 個 GroupBox、同步變數名與 Header、補 tooltip、修錯字、加寬視窗 | 結構最接近現況，使用者無陌生感；更大幅重組留待後續使用者反饋觸發 |
+| **Miscellaneous → Display** | GlobalConfig 的 `Miscellaneous` GroupBox 更名為 `Display` | 剩下的 `ShowInMainMenu` 確實只與 UI 顯示相關，語意更精準 |
+| **視窗尺寸策略** | `SizeToContent="Height"` + `MinWidth="420"` | 移除寫死的 `Height="377.16"` 老派做法；寬度 420 可完整顯示長 locale 名稱 |
+| **About 分頁內容** | 產品名 + 版本、原作者致謝、GitHub 連結、LGPL-3.0 授權連結 | 基本資訊四項，不過度設計 |
+| **既有 tech debt** | 一併修復：空標題對話框、`IsChecked` null check 現代化、`CREATE__SUSPENDED` 錯字、`BlurEffect` 改直接 modal、Save 成功狀態提示 | 動 UI 時順手解決，避免短期內二次觸碰 |
+
+---
+
+## 3. 架構設計
+
+### 3.1 元件拆分
+
+```
+src/LEGUI/
+├── GlobalConfig.xaml / .cs             # 主視窗 A：全域 profile 管理
+│   └── TabControl: [Profile] [Shell Extension] [About]
+├── AppConfig.xaml / .cs                # 主視窗 B：單檔 .le.config 編輯
+│   └── TabControl: [Profile] [About]
+├── ProfileEditorControl.xaml / .cs     # 【新增】共用 UserControl
+│   └── 4 個 GroupBox：Locale / Timezone / Advanced / Display
+├── ShellExtensionPanel.xaml / .cs      # 【新增】UserControl
+│   └── Current User 區 + All Users 區 + 舊版清理區
+├── AboutPanel.xaml / .cs               # 【新增】UserControl
+├── ShellExtensionRegistrar.cs          # 【既有】後端不動
+├── ShellExtensionConstants.cs          # 【既有】不動
+└── App.xaml.cs                         # 加入 --shell-ext CLI 處理
+```
+
+### 3.2 ProfileEditorControl API
+
+```csharp
+public partial class ProfileEditorControl : UserControl
+{
+    // 綁定當前編輯的 profile
+    public LEProfile Profile { get; set; }
+
+    // AppConfig 設 false（單檔模式無 ShowInMainMenu 概念）
+    public static readonly DependencyProperty ShowDisplayOptionsProperty =
+        DependencyProperty.Register(nameof(ShowDisplayOptions), typeof(bool),
+            typeof(ProfileEditorControl), new PropertyMetadata(true));
+
+    public bool ShowDisplayOptions { get; set; }
+}
+```
+
+- 使用 `DependencyProperty` 讓 `ShowDisplayOptions` 可在 XAML 內直接設定並支援 binding。
+- `Profile` 屬性的同步模型：
+  - **Setter（載入）**：外部設定 `Profile = someLeProfile` 時，UserControl 將欄位值填入內部的 ComboBox / CheckBox 控制項
+  - **取值（儲存）**：UserControl 對外暴露 `LEProfile ReadCurrentValues()` 方法，從內部控制項讀出當前使用者編輯的值並回傳新 `LEProfile`
+  - **GlobalConfig 使用方式**：`cbGlobalProfiles_SelectionChanged` 時設定 `profileEditor.Profile = _profiles[selectedIndex]`；`bSaveGlobalSetting_Click` 時 `_profiles[selectedIndex] = profileEditor.ReadCurrentValues()`
+  - 不引入 MVVM framework、不使用 `INotifyPropertyChanged`，維持既有 code-behind 模式
+
+### 3.3 Shell Extension 分頁內部佈局
+
+```
+┌──────────────────────────────────────────────┐
+│ ┌ Current User ─────────────────────────────┐│
+│ │  Status: Installed / Not Installed         ││
+│ │  [Install]       [Uninstall]               ││
+│ └────────────────────────────────────────────┘│
+│ ┌ All Users 🛡 ──────────────────────────────┐│
+│ │  Status: Installed / Not Installed         ││
+│ │  [Install 🛡]    [Uninstall 🛡]            ││
+│ └────────────────────────────────────────────┘│
+│                                                │
+│ ⚠ Old version residue detected                 │
+│ [Clean up old registration 🛡]                 │
+│ （條件性顯示：HasOldRegistration() == true）    │
+└──────────────────────────────────────────────┘
+```
+
+**按鈕狀態規則**：
+
+- `Install (mode)`：`IsInstalled(mode) == true` 時 disabled
+- `Uninstall (mode)`：`IsInstalled(mode) == false` 時 disabled
+- 🛡 圖示表示「按下會觸發 UAC」；若當前 process 已是 admin，`runas` verb 不會再彈 UAC
+- 舊版清理區塊以 `Visibility="Collapsed"` 預設隱藏，`OnLoaded` 時呼叫 `HasOldRegistration()` 決定是否顯示
+
+---
+
+## 4. UAC 升權流程
+
+### 4.1 CLI 參數設計
+
+在 `App.xaml.cs` 的 `App_OnStartup` 處理新增支援：
+
+```
+LEGUI.exe --shell-ext <verb> <scope>
+  verb  = install | uninstall | cleanup-old
+  scope = current-user | all-users
+```
+
+範例：
+
+```
+LEGUI.exe --shell-ext install all-users      # 寫 HKLM（需 admin）
+LEGUI.exe --shell-ext uninstall current-user # 刪 HKCU
+LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 admin）
+```
+
+### 4.2 執行流程
+
+使用者在 UI 按「Install (All Users) 🛡」時：
+
+1. 主 LEGUI 判定當前 token 是否為 admin（`SystemHelper.IsAdministrator()`）。
+2. 若已是 admin，直接呼叫 `ShellExtensionRegistrar.Register(AllUsers, dllPath)`，完成後刷新 UI 狀態。
+3. 若非 admin，啟動子 process，並以非同步方式等待完成以不阻塞 UI thread：
+   ```csharp
+   var psi = new ProcessStartInfo
+   {
+       FileName = Environment.ProcessPath,
+       Arguments = "--shell-ext install all-users",
+       Verb = "runas",           // 觸發 UAC
+       UseShellExecute = true
+   };
+   using var p = Process.Start(psi);
+   button.IsEnabled = false;     // 防止重複點擊
+   await p.WaitForExitAsync();   // 非同步等待，不阻塞 UI
+   button.IsEnabled = true;
+   RefreshStatus(p.ExitCode);
+   ```
+4. 子 process 啟動後走 CLI 路徑：不顯示 UI，執行對應 `ShellExtensionRegistrar` 方法，`ExitCode` 0 = 成功、非 0 = 失敗。
+5. 主 process 讀取 `ExitCode`，刷新 `IsInstalled()` 狀態並顯示成功/失敗訊息（i18n key `InstallSuccess` / 錯誤訊息）。
+
+**Async 注意事項**：UI 事件 handler 改為 `async void`（WPF 慣例），`WaitForExitAsync()` 保證 UI 執行緒在 UAC 對話框彈出期間仍能回應（雖然 UAC 對話框本身會遮蔽整個桌面，這是系統行為）。
+
+### 4.3 取消與錯誤處理
+
+- 使用者在 UAC 對話框點「否」：`Process.Start` 拋 `Win32Exception` (code 1223)，主 process 捕獲並視為使用者取消，UI 不顯示錯誤。
+- 其他失敗（如 DLL 路徑錯誤、登錄檔鎖定）：子 process 以非 0 ExitCode 退出，主 process 顯示通用錯誤訊息。
+
+---
+
+## 5. Profile 分頁重構細項
+
+### 5.1 版面修正對照表
+
+| 項目 | Before | After |
+|------|--------|-------|
+| 視窗尺寸 | `Height="377.16" Width="310"` | `SizeToContent="Height" MinWidth="420"` |
+| `DebugOptions` GroupBox 變數名 | Header 寫 "Advanced Options"，變數叫 `DebugOptions` | 變數改名 `advancedOptionsGroup`，Header 維持 "Advanced Options" |
+| CheckBox tooltip | 無 | 每個 CheckBox 加 `ToolTip`（英文；其他語言翻譯屬 Issue 21） |
+| `CREATE__SUSPENDED` 錯字 | i18n key 值寫 `CREATE__SUSPENDED`（雙底線） | 改 `CREATE_SUSPENDED` |
+| Miscellaneous GroupBox | 只包含 `ShowInMainMenu` 一項 | 改名 `Display`，語意更精準；新增 i18n key `Display` |
+
+### 5.2 Tooltip 文案（英文版，放入 `DefaultLanguage.xaml`）
+
+| CheckBox | Tooltip i18n key | 內容 |
+|----------|------------------|------|
+| Run as administrator | `AsAdminTip` | Launch the target process with elevated privileges. Required for some games. |
+| Fake language-related keys in Registry | `RedirectRegistryTip` | Intercept Registry reads for locale-related keys, returning the emulated locale instead of the system's. |
+| Fake system UI language | `IsAdvancedRedirectionTip` | Also redirect Registry keys that control system UI language, affecting some apps that query via `MUI_LANGUAGE_NAME`. |
+| Create process with CREATE_SUSPENDED | `WithCREATESUSPENDEDTip` | Create the target process in suspended state (advanced debugging option). |
+| Show in Shell Extension top-level menu | `ShowInMainMenuTip` | Display this profile directly in the right-click menu root instead of under a submenu. |
+
+### 5.3 其他 tech debt 修正
+
+| 項目 | Before | After |
+|------|--------|-------|
+| 空標題對話框 | `MessageBox.Show(I18n.GetString("ConfirmDel"), "", ...)` | 第二參數改傳 `"Locale Emulator"` |
+| null check 樣板 | `IsChecked != null && (bool)IsChecked` | `IsChecked == true` |
+| `SaveAs` 的 `BlurEffect` | 手動套用 `BlurEffect` + 取消 | 移除，依賴 `ShowDialog()` 的 modal 行為 |
+| Save 成功提示 | 無任何視覺回饋 | 在視窗底部加一 `StatusBar`，儲存成功時顯示 "Saved"，3 秒後淡出（或改顏色） |
+
+---
+
+## 6. About 分頁內容
+
+```
+┌──────────────────────────────────────────────┐
+│  Locale Emulator (Chu's fork)                │
+│  Version 3.0.0-dev                           │
+│                                              │
+│  Original project: https://github.com/       │
+│    xupefei/Locale-Emulator                   │
+│  Core: https://github.com/xupefei/           │
+│    Locale-Emulator-Core (archived 2022-04)   │
+│  This fork: https://github.com/ooxxTaiwan/   │
+│    Locale-Emulator-J                         │
+│                                              │
+│  License: LGPL-3.0                           │
+│  Core portion: LGPL-3.0 / GPL-3.0            │
+└──────────────────────────────────────────────┘
+```
+
+- 版本號從 `Assembly.GetExecutingAssembly().GetName().Version` 讀取。
+- 連結為 `Hyperlink`（WPF 原生），點擊以系統預設瀏覽器開啟。
+- 內容不 i18n 到其他 22 種語言，僅英文（屬 Issue 21 範圍）。
+
+---
+
+## 7. 範圍邊界
+
+### 7.1 本次做（in scope）
+
+- [x] GlobalConfig 和 AppConfig 改 TabControl 結構
+- [x] 抽出 `ProfileEditorControl` UserControl
+- [x] 新增 Shell Extension 分頁（含 Install / Uninstall / 舊版清理）
+- [x] 新增 About 分頁
+- [x] CLI 參數 `--shell-ext` 支援（子 process 提權路徑）
+- [x] Profile 分頁版面修正（變數名同步、tooltip、錯字、尺寸）
+- [x] 其他 tech debt（空標題對話框、null check、BlurEffect、Save 成功提示）
+- [x] 英文 i18n key 加入 `DefaultLanguage.xaml`
+- [x] LEGUI.Tests 覆蓋新元件邏輯
+
+### 7.2 本次不做（out of scope）
+
+- **其他 21 種語言翻譯**：屬 Issue 21，本次僅加英文 key
+- **ADS (Zone Identifier) 移除**：屬 Issue 20
+- **LEUpdater 重新設計**：屬 Issue 11
+- **合併 GlobalConfig 與 AppConfig 為單一視窗**：屬重大重構，另案
+- **XAML 自訂主題/樣式系統**：維持現有樸素風格
+- **MVVM framework 導入**：維持現有 code-behind 模式，避免本次引入大量樣板
+
+---
+
+## 8. 測試策略
+
+### 8.1 單元測試（`tests/LEGUI.Tests/`）
+
+- `ProfileEditorControlTests`：載入 / 儲存 LEProfile 的欄位雙向同步（Location、Timezone、各 CheckBox）、`ShowDisplayOptions = false` 時 Display GroupBox 隱藏
+- `ShellExtensionPanelTests`：按鈕啟用/停用狀態對應 `IsInstalled()` 結果、舊版清理區塊條件顯示邏輯
+- `CliArgumentParserTests`：`--shell-ext install all-users` 等組合正確解析成對應動作
+- 既有 `ShellExtensionRegistrarTests` 不受影響
+
+### 8.2 手動驗證（Release build 實測）
+
+- 開啟 LEGUI，切至 Shell Extension 分頁，安裝（Current User），確認 Explorer 右鍵出現 LE 選單
+- 解除安裝，確認右鍵選單消失
+- 安裝（All Users），確認 UAC 彈出、子 process 寫 HKLM 成功、主 UI 狀態刷新
+- 舊版 CLSID 手動寫入 HKCU，開啟 LEGUI 確認清理提示出現，執行清理後提示消失
+- 拖放 `game.exe` 至 LEGUI 測試 AppConfig 模式，確認 Shell Extension 分頁**不存在**、About 分頁存在
+
+---
+
+## 9. 風險與回滾
+
+| 風險 | 影響 | 緩解 |
+|------|------|------|
+| 子 process 啟動自身 LEGUI.exe，CLI 路徑萬一顯示 UI 會造成假死 | 嚴重 | 子 process 路徑嚴格走 `Application.Current.Shutdown()`，不 `InitializeComponent` 任何 Window |
+| `ProfileEditorControl` 的 `Profile` 屬性單向同步若處理不當會遺失編輯 | 中 | 單元測試覆蓋雙向同步；保留既有 `bSaveGlobalSetting_Click` 的完整欄位逐項寫回邏輯 |
+| `SizeToContent` 可能在某些 DPI 設定下產生視窗跳動 | 低 | 若實測出現問題，降級為固定尺寸（`MinWidth + MinHeight`） |
+| 既有使用者習慣 310×377 視窗尺寸，改 420 後不適應 | 低 | 視窗尺寸變化屬可接受的改善，不提供向下相容選項 |
+
+**回滾策略**：本改動集中在 LEGUI 專案，不動 LEProc / Core / ShellExtension，若出現嚴重問題可單獨 revert LEGUI 的 commits，其他元件不受影響。
+
+---
+
+## 10. 設計階段提案與討論記錄
+
+為保留決策透明度，本節記錄本次 brainstorming 中提出的替代方案與捨棄原因。
+
+### 10.1 UI scope
+
+- **Scope 1**（僅 GlobalConfig 改）被捨棄：會讓兩視窗版面分歧，未來維護成本更高
+- **Scope 3**（合併兩視窗）被捨棄：偏離 issue 19 主軸，屬大型 refactoring，應另案
+
+### 10.2 Tab 結構
+
+- **方案 A**（不對稱：僅 GlobalConfig 有 Tab）被捨棄：兩視窗視覺差異大，感覺像兩個不同 app
+- **方案 C**（完全對稱，AppConfig 也含 Shell Extension）被捨棄：語意錯位，使用者會誤以為是為單一 exe 安裝擴充
+
+### 10.3 Shell Extension 分頁佈局
+
+- **方案 A**（扁平 4 按鈕）被捨棄：狀態和動作未就近擺放，需跨區域視線移動
+- **方案 C**（單一動作 + radio button）被捨棄：掩蓋「兩模式可並存」的事實，若 CU 已裝 AU 未裝無法如實表達
+
+### 10.4 UAC 升權策略
+
+- **方案 A**（重啟整個 LEGUI）被捨棄：Profile 分頁未儲存編輯會遺失，重啟後使用者還要再點一次按鈕
+- **方案 C**（不特殊處理，讓失敗）被捨棄：違反 Windows 慣例（🛡 應主動觸發 UAC），UX 最差
+
+### 10.5 Profile 分頁重構
+
+- **方案 B**（併 Display 到 Advanced）被捨棄：UI 顯示和執行權限概念不同，強行合併語意糊
+- **方案 C**（語意重組四分組）被捨棄：偏離既有習慣較多，本次以「最小修改」為原則，進階重組留待使用者回饋觸發
+
+---
+
+## 11. 實作順序建議
+
+預估分為 6 個 logical 步驟，每步驟應有獨立的測試覆蓋並各自可 commit：
+
+1. 新增 `ProfileEditorControl` UserControl（含測試），暫不接入主視窗
+2. 重構 `GlobalConfig.xaml` 改用 TabControl，Profile 分頁放入 ProfileEditorControl
+3. 重構 `AppConfig.xaml` 同步改 TabControl
+4. 新增 `ShellExtensionPanel` + Shell Extension 分頁（UI 層先不處理 UAC）
+5. 新增 CLI 參數 `--shell-ext` 處理 + 子 process 提權邏輯
+6. 新增 About 分頁 + 清掃既有 tech debt（MessageBox 標題、null check、BlurEffect、Save 提示）
+
+詳細實作計畫（TDD 循環、子任務拆分、驗收標準）由後續的 writing-plans 階段產出。
+
+---
+
+## 12. 相關文件
+
+- Issue: ooxxTaiwan/Locale-Emulator-J#19
+- 相關 issue：#20 (ADS 移除)、#21 (i18n 翻譯)
+- 後端實作（已完成）：`src/LEGUI/ShellExtensionRegistrar.cs`
+- 先前設計文件：`docs/superpowers/specs/2026-03-28-dotnet10-migration-design.md`

--- a/docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md
@@ -59,27 +59,53 @@ src/LEGUI/
 
 ### 3.2 ProfileEditorControl API
 
+**事實前提**：`LEProfile` 是 **`struct`**（value type）— 詳 `src/LECommonLibrary/LEProfile.cs`。這意味著 `ApplyTo(LEProfile)` 之類直接修改參數的寫法無效（參數是複本）；必須採「傳入 template、回傳新 struct」或 `ref` 參數。本設計採前者（immutable 風格，與既有 `bSaveGlobalSetting_Click` 的寫回模式一致）。
+
 ```csharp
 public partial class ProfileEditorControl : UserControl
 {
-    // 綁定當前編輯的 profile
-    public LEProfile Profile { get; set; }
-
     // AppConfig 設 false（單檔模式無 ShowInMainMenu 概念）
     public static readonly DependencyProperty ShowDisplayOptionsProperty =
         DependencyProperty.Register(nameof(ShowDisplayOptions), typeof(bool),
             typeof(ProfileEditorControl), new PropertyMetadata(true));
 
-    public bool ShowDisplayOptions { get; set; }
+    public bool ShowDisplayOptions
+    {
+        get => (bool)GetValue(ShowDisplayOptionsProperty);
+        set => SetValue(ShowDisplayOptionsProperty, value);
+    }
+
+    /// <summary>載入 profile 至 UI 控制項。</summary>
+    public void LoadProfile(LEProfile source) { /* 填 UI */ }
+
+    /// <summary>讀回 UI 當前值，以 template 為基礎建立新 LEProfile。</summary>
+    /// <remarks>保留 template 的 Name / Guid / Parameter（UserControl 不管這些欄位）。
+    /// ShowDisplayOptions=false 時，ShowInMainMenu 也沿用 template 的值，不被 UI 覆寫。</remarks>
+    public LEProfile ReadProfile(LEProfile template) { /* 回傳新 struct */ }
 }
 ```
 
-- 使用 `DependencyProperty` 讓 `ShowDisplayOptions` 可在 XAML 內直接設定並支援 binding。
-- `Profile` 屬性的同步模型：
-  - **Setter（載入）**：外部設定 `Profile = someLeProfile` 時，UserControl 將欄位值填入內部的 ComboBox / CheckBox 控制項
-  - **取值（儲存）**：UserControl 對外暴露 `LEProfile ReadCurrentValues()` 方法，從內部控制項讀出當前使用者編輯的值並回傳新 `LEProfile`
-  - **GlobalConfig 使用方式**：`cbGlobalProfiles_SelectionChanged` 時設定 `profileEditor.Profile = _profiles[selectedIndex]`；`bSaveGlobalSetting_Click` 時 `_profiles[selectedIndex] = profileEditor.ReadCurrentValues()`
-  - 不引入 MVVM framework、不使用 `INotifyPropertyChanged`，維持既有 code-behind 模式
+**呼叫模式（GlobalConfig）**：
+
+```csharp
+// 切換選取時
+private void cbGlobalProfiles_SelectionChanged(...)
+{
+    profileEditor.LoadProfile(_profiles[cbGlobalProfiles.SelectedIndex]);
+}
+
+// 儲存時
+private void bSaveGlobalSetting_Click(...)
+{
+    var idx = cbGlobalProfiles.SelectedIndex;
+    _profiles[idx] = profileEditor.ReadProfile(_profiles[idx]);
+    LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
+}
+```
+
+- `DependencyProperty` 只用於 `ShowDisplayOptions`（支援 XAML 靜態設定，AppConfig 在 XAML 寫 `ShowDisplayOptions="False"`）。
+- `LoadProfile` / `ReadProfile` 為普通方法（非 Property），避免 getter/setter 語意被誤用為 data binding。
+- 不引入 MVVM framework、不使用 `INotifyPropertyChanged`。
 
 ### 3.3 Shell Extension 分頁內部佈局
 
@@ -118,7 +144,7 @@ public partial class ProfileEditorControl : UserControl
 ```
 LEGUI.exe --shell-ext <verb> <scope>
   verb  = install | uninstall | cleanup-old
-  scope = current-user | all-users
+  scope = current-user | all-users (cleanup-old 時可省略)
 ```
 
 範例：
@@ -128,6 +154,48 @@ LEGUI.exe --shell-ext install all-users      # 寫 HKLM（需 admin）
 LEGUI.exe --shell-ext uninstall current-user # 刪 HKCU
 LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 admin）
 ```
+
+**CLI 分支的執行流程（在 `App_OnStartup` 最前端加分支判斷）**：
+
+```csharp
+if (e.Args.Length >= 1 && e.Args[0] == "--shell-ext")
+{
+    int exitCode = HandleShellExtCommand(e.Args);
+    Current.Shutdown(exitCode);
+    return;   // 跳過 CheckPermission / LoadLanguage / StartupUri
+}
+```
+
+- **不執行** 既有的 `CheckPermission` 檢查（Shell Extension 操作不需要寫入 LEGUI 目錄）
+- **不執行** `I18n.LoadLanguage`（CLI 子 process 不顯示 UI）
+- **不設定** `StartupUri`（不開啟任何 Window）
+- `HandleShellExtCommand` 解析 verb/scope 後呼叫對應的 `ShellExtensionRegistrar` 方法，以 `ExitCode` 0/非 0 表示成功/失敗
+
+### 4.1.1 DLL 路徑解析
+
+`ShellExtensionRegistrar.AutoDetectDllPath(basePath, is64)` 期待 `basePath/x86/ShellExtension.dll` 或 `basePath/x64/ShellExtension.dll`。
+
+部署佈局（per CLAUDE.md）：
+
+```
+Build/Release/
+├─ x86/
+│   ├─ LEGUI.exe          ← Environment.ProcessPath 位置
+│   └─ ShellExtension.dll
+└─ x64/
+    └─ ShellExtension.dll
+```
+
+因此 `basePath` 必須是 `Build/Release/`（x86 的父目錄）：
+
+```csharp
+var legui = Environment.ProcessPath!;               // .../Build/Release/x86/LEGUI.exe
+var basePath = Path.GetDirectoryName(
+                    Path.GetDirectoryName(legui))!; // .../Build/Release/
+var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+```
+
+**開發時（`dotnet run` / VS Debug）的邊界**：開發 LEGUI 輸出於 `src/LEGUI/bin/Debug/net10.0-windows/`，此目錄無 `x86/x64` 子目錄。嘗試安裝會因 `ShellExtension.dll` 不存在而失敗；此時顯示友善錯誤訊息「ShellExtension.dll not found at: {path}. Build the full solution first.」而非 crash。
 
 ### 4.2 執行流程
 
@@ -172,7 +240,7 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 | `DebugOptions` GroupBox 變數名 | Header 寫 "Advanced Options"，變數叫 `DebugOptions` | 變數改名 `advancedOptionsGroup`，Header 維持 "Advanced Options" |
 | CheckBox tooltip | 無 | 每個 CheckBox 加 `ToolTip`（英文；其他語言翻譯屬 Issue 21） |
 | `CREATE__SUSPENDED` 錯字 | i18n key 值寫 `CREATE__SUSPENDED`（雙底線） | 改 `CREATE_SUSPENDED` |
-| Miscellaneous GroupBox | 只包含 `ShowInMainMenu` 一項 | 改名 `Display`，語意更精準；新增 i18n key `Display` |
+| Miscellaneous GroupBox | 只包含 `ShowInMainMenu` 一項 | 改名 `Display`，語意更精準；在 `DefaultLanguage.xaml` 新增 `<system:String x:Key="Display">Display</system:String>`（移除既有 `Miscellaneous` key） |
 
 ### 5.2 Tooltip 文案（英文版，放入 `DefaultLanguage.xaml`）
 
@@ -191,7 +259,7 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 | 空標題對話框 | `MessageBox.Show(I18n.GetString("ConfirmDel"), "", ...)` | 第二參數改傳 `"Locale Emulator"` |
 | null check 樣板 | `IsChecked != null && (bool)IsChecked` | `IsChecked == true` |
 | `SaveAs` 的 `BlurEffect` | 手動套用 `BlurEffect` + 取消 | 移除，依賴 `ShowDialog()` 的 modal 行為 |
-| Save 成功提示 | 無任何視覺回饋 | 在視窗底部加一 `StatusBar`，儲存成功時顯示 "Saved"，3 秒後淡出（或改顏色） |
+| Save 成功提示 | 無任何視覺回饋 | 在**主視窗**（`GlobalConfig.xaml` / `AppConfig.xaml`）底部加一 `StatusBar`（不在 `ProfileEditorControl` 內），儲存成功時顯示 "Saved"，3 秒後淡出（以 `DispatcherTimer` 觸發） |
 
 ---
 
@@ -199,8 +267,8 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 
 ```
 ┌──────────────────────────────────────────────┐
-│  Locale Emulator (Chu's fork)                │
-│  Version 3.0.0-dev                           │
+│  Locale Emulator (ooxxTaiwan fork)           │
+│  Version 3.0.0                               │
 │                                              │
 │  Original project: https://github.com/       │
 │    xupefei/Locale-Emulator                   │
@@ -214,8 +282,8 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 └──────────────────────────────────────────────┘
 ```
 
-- 版本號從 `Assembly.GetExecutingAssembly().GetName().Version` 讀取。
-- 連結為 `Hyperlink`（WPF 原生），點擊以系統預設瀏覽器開啟。
+- 版本號從 `Assembly.GetExecutingAssembly().GetName().Version` 讀取（目前為 `3.0.0`，定義於 `src/LEGUI/LEGUI.csproj` 的 `<Version>` 屬性）。
+- 連結為 WPF `Hyperlink`，`NavigateUri` 綁定實際 URL，`RequestNavigate` 事件處理 `Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true })`。
 - 內容不 i18n 到其他 22 種語言，僅英文（屬 Issue 21 範圍）。
 
 ---
@@ -249,10 +317,10 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 
 ### 8.1 單元測試（`tests/LEGUI.Tests/`）
 
-- `ProfileEditorControlTests`：載入 / 儲存 LEProfile 的欄位雙向同步（Location、Timezone、各 CheckBox）、`ShowDisplayOptions = false` 時 Display GroupBox 隱藏
+- `ProfileEditorControlTests`：`LoadProfile` / `ReadProfile` 的欄位雙向同步（Location、Timezone、各 CheckBox）、`ShowDisplayOptions = false` 時 `ReadProfile` 不覆寫 template 的 `ShowInMainMenu`、Display GroupBox 隱藏
 - `ShellExtensionPanelTests`：按鈕啟用/停用狀態對應 `IsInstalled()` 結果、舊版清理區塊條件顯示邏輯
 - `CliArgumentParserTests`：`--shell-ext install all-users` 等組合正確解析成對應動作
-- 既有 `ShellExtensionRegistrarTests` 不受影響
+- 既有 `ShellExtensionRegistrarTests`、`I18nTests` 不受影響（命名慣例：`XxxTests`，無底線）
 
 ### 8.2 手動驗證（Release build 實測）
 
@@ -272,6 +340,8 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 | `ProfileEditorControl` 的 `Profile` 屬性單向同步若處理不當會遺失編輯 | 中 | 單元測試覆蓋雙向同步；保留既有 `bSaveGlobalSetting_Click` 的完整欄位逐項寫回邏輯 |
 | `SizeToContent` 可能在某些 DPI 設定下產生視窗跳動 | 低 | 若實測出現問題，降級為固定尺寸（`MinWidth + MinHeight`） |
 | 既有使用者習慣 310×377 視窗尺寸，改 420 後不適應 | 低 | 視窗尺寸變化屬可接受的改善，不提供向下相容選項 |
+| DLL 路徑解析在開發環境（`bin/Debug`）無 x86/x64 子目錄結構，導致測試安裝失敗 | 低 | 顯示友善錯誤訊息而非 crash；開發時以 `regsvr32` 手動註冊測試；CI 環境使用完整 `Build/Release/` 結構 |
+| `SizeToContent="Height"` 在 TabControl 切換分頁時可能造成視窗跳動（不同分頁內容高度不同） | 中 | 實測若有跳動，改為固定 `MinHeight` + `MaxHeight=SizeToContent` 或手動設置各分頁容器 `MinHeight` 統一基線 |
 
 **回滾策略**：本改動集中在 LEGUI 專案，不動 LEProc / Core / ShellExtension，若出現嚴重問題可單獨 revert LEGUI 的 commits，其他元件不受影響。
 
@@ -329,3 +399,22 @@ LEGUI.exe --shell-ext cleanup-old            # 清 HKCU + HKLM 舊 CLSID（需 a
 - 相關 issue：#20 (ADS 移除)、#21 (i18n 翻譯)
 - 後端實作（已完成）：`src/LEGUI/ShellExtensionRegistrar.cs`
 - 先前設計文件：`docs/superpowers/specs/2026-03-28-dotnet10-migration-design.md`
+
+---
+
+## 13. 自審修正紀錄（2026-04-18 spec 提交後）
+
+本節記錄 spec 首次 commit（`7eb5540`）後的自審修正，便於追蹤決策演進。
+
+| 修正點 | 問題 | 處理方式 |
+|--------|------|----------|
+| `ProfileEditorControl.Profile { get; set; }` 設計 | `LEProfile` 是 **struct**（value type），單純 setter 無法表達「寫回」語意；且 UserControl 不該管 Name/Guid 這些外層欄位 | API 改為 `LoadProfile(LEProfile)` + `ReadProfile(LEProfile template) → LEProfile`，以 template 模式保留外層欄位 |
+| `AutoDetectDllPath` 的 `basePath` 未說明 | 實際部署時 `LEGUI.exe` 位於 `Build/Release/x86/`，但 `AutoDetectDllPath` 期望 basePath 為上一層 | 明訂 `basePath = Path.GetDirectoryName(Path.GetDirectoryName(Environment.ProcessPath))`；加入開發環境無 x86/x64 子目錄的錯誤處理 |
+| `App.xaml.cs` 的 `--shell-ext` 分支未定義 | 只說「不顯示 UI」，未列出要跳過哪些既有啟動步驟 | 明列跳過 `CheckPermission` / `LoadLanguage` / `StartupUri` 三項 |
+| About 版本號寫 `3.0.0-dev` | 實際 csproj 為 `3.0.0`（無 `-dev` 後綴） | 改為 `3.0.0`，並註明從 `Assembly.GetName().Version` 讀取 |
+| 測試類別命名 `ProfileEditorControl_Tests` 有底線 | 既有測試為 `ShellExtensionRegistrarTests`、`I18nTests`，無底線 | 改為 `XxxTests` 一致命名 |
+| StatusBar 位置未指定 | 容易誤實作在 `ProfileEditorControl` 內 | 明訂在主視窗（`GlobalConfig` / `AppConfig`）底部 |
+| Display i18n key 未指定新舊替換 | 可能遺漏更新 `Miscellaneous` key | 明訂新增 `Display` key、移除 `Miscellaneous` key |
+| `ShowInMainMenu` 在 AppConfig 的序列化副作用 | `ShowDisplayOptions=false` 時若 `ReadProfile` 仍讀 UI 預設值會覆寫 template | 明訂 `ReadProfile` 在 `ShowDisplayOptions=false` 時沿用 template 的 `ShowInMainMenu` |
+| `WaitForExit` 阻塞 UI | 原 spec 用同步 `WaitForExit` | 改 `await p.WaitForExitAsync()`，handler 改 `async void`（WPF 慣例） |
+| `SizeToContent` 切換分頁可能跳動 | 原 spec 未提分頁切換情境 | 新增風險項目與備援方案（統一 `MinHeight`） |

--- a/src/LEGUI/AboutPanel.xaml
+++ b/src/LEGUI/AboutPanel.xaml
@@ -1,0 +1,35 @@
+<UserControl x:Class="LEGUI.AboutPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="20" TextElement.FontFamily="{DynamicResource UIFont}">
+        <TextBlock FontSize="16" FontWeight="Bold">
+            Locale Emulator (ooxxTaiwan fork)
+        </TextBlock>
+        <TextBlock Margin="0,4,0,0">
+            <Run Text="Version " /><Run x:Name="tVersion" />
+        </TextBlock>
+        <TextBlock Margin="0,16,0,0" FontWeight="Bold">Original project</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/xupefei/Locale-Emulator"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/xupefei/Locale-Emulator
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,8,0,0" FontWeight="Bold">Core (archived 2022-04)</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/xupefei/Locale-Emulator-Core"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/xupefei/Locale-Emulator-Core
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,8,0,0" FontWeight="Bold">This fork</TextBlock>
+        <TextBlock>
+            <Hyperlink NavigateUri="https://github.com/ooxxTaiwan/Locale-Emulator-J"
+                       RequestNavigate="Hyperlink_RequestNavigate">
+                github.com/ooxxTaiwan/Locale-Emulator-J
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Margin="0,16,0,0">License: LGPL-3.0</TextBlock>
+        <TextBlock>Core portion: LGPL-3.0 / GPL-3.0</TextBlock>
+    </StackPanel>
+</UserControl>

--- a/src/LEGUI/AboutPanel.xaml.cs
+++ b/src/LEGUI/AboutPanel.xaml.cs
@@ -1,0 +1,24 @@
+#nullable disable
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+
+namespace LEGUI;
+
+public partial class AboutPanel : UserControl
+{
+    public AboutPanel()
+    {
+        InitializeComponent();
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        tVersion.Text = version?.ToString(3) ?? "unknown";
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        e.Handled = true;
+    }
+}

--- a/src/LEGUI/AboutPanel.xaml.cs
+++ b/src/LEGUI/AboutPanel.xaml.cs
@@ -1,9 +1,9 @@
 #nullable disable
 
 using System.Diagnostics;
-using System.Reflection;
 using System.Windows.Controls;
 using System.Windows.Navigation;
+using LECommonLibrary;
 
 namespace LEGUI;
 
@@ -12,8 +12,7 @@ public partial class AboutPanel : UserControl
     public AboutPanel()
     {
         InitializeComponent();
-        var version = Assembly.GetExecutingAssembly().GetName().Version;
-        tVersion.Text = version?.ToString(3) ?? "unknown";
+        tVersion.Text = GlobalHelper.GetVersionString();
     }
 
     private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/src/LEGUI/App.xaml.cs
+++ b/src/LEGUI/App.xaml.cs
@@ -35,9 +35,9 @@ public partial class App : Application
 
         // Reject malformed --shell-ext invocations instead of falling through to file-path
         // mode (which would treat "--shell-ext" as a dropped file and open AppConfig).
-        if (e.Args.Length > 0 && e.Args[0] == "--shell-ext")
+        if (e.Args.Length > 0 && e.Args[0] == ShellExtCliCommand.Prefix)
         {
-            System.Diagnostics.Debug.WriteLine($"Malformed --shell-ext invocation: {string.Join(' ', e.Args)}");
+            System.Diagnostics.Debug.WriteLine($"Malformed {ShellExtCliCommand.Prefix} invocation: {string.Join(' ', e.Args)}");
             Current.Shutdown(2);
             return;
         }
@@ -118,14 +118,8 @@ public partial class App : Application
     {
         try
         {
-            var processPath = Environment.ProcessPath;
-            string basePath = null;
-            if (!string.IsNullOrEmpty(processPath))
-                basePath = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
-            if (string.IsNullOrEmpty(basePath))
-                basePath = AppContext.BaseDirectory;
-
-            var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+            var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(
+                ShellExtensionRegistrar.GetBuildOutputRoot());
             var registrar = new ShellExtensionRegistrar(
                 new RegistryOperations(),
                 ShellExtensionConstants.NewClsid);

--- a/src/LEGUI/App.xaml.cs
+++ b/src/LEGUI/App.xaml.cs
@@ -23,6 +23,16 @@ public partial class App : Application
 
     private void App_OnStartup(object sender, StartupEventArgs e)
     {
+        // If running as a --shell-ext sub-process (e.g. spawned from ShellExtensionPanel
+        // to elevate for an HKLM write), bypass all UI startup and execute the command.
+        var cli = ShellExtCliCommand.Parse(e.Args);
+        if (cli != null)
+        {
+            int exitCode = ExecuteShellExtCommand(cli);
+            Current.Shutdown(exitCode);
+            return;
+        }
+
         if (e.Args.Length != 0)
         {
             StandaloneFilePath = SystemHelper.EnsureAbsolutePath(e.Args[0]);
@@ -93,5 +103,42 @@ public partial class App : Application
         Current.StartupUri = isGlobalProfile
                                  ? new Uri("GlobalConfig.xaml", UriKind.RelativeOrAbsolute)
                                  : new Uri("AppConfig.xaml", UriKind.RelativeOrAbsolute);
+    }
+
+    private int ExecuteShellExtCommand(ShellExtCliCommand cli)
+    {
+        try
+        {
+            var processPath = Environment.ProcessPath;
+            string basePath = null;
+            if (!string.IsNullOrEmpty(processPath))
+                basePath = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
+            if (string.IsNullOrEmpty(basePath))
+                basePath = AppContext.BaseDirectory;
+
+            var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+            var registrar = new ShellExtensionRegistrar(
+                new RegistryOperations(),
+                ShellExtensionConstants.NewClsid);
+
+            switch (cli.ActionVerb)
+            {
+                case ShellExtCliCommand.Verb.Install:
+                    registrar.Register(cli.Mode, dllPath);
+                    break;
+                case ShellExtCliCommand.Verb.Uninstall:
+                    registrar.Unregister(cli.Mode);
+                    break;
+                case ShellExtCliCommand.Verb.CleanupOld:
+                    registrar.CleanupOldRegistration();
+                    break;
+            }
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"--shell-ext failed: {ex}");
+            return 1;
+        }
     }
 }

--- a/src/LEGUI/App.xaml.cs
+++ b/src/LEGUI/App.xaml.cs
@@ -33,6 +33,15 @@ public partial class App : Application
             return;
         }
 
+        // Reject malformed --shell-ext invocations instead of falling through to file-path
+        // mode (which would treat "--shell-ext" as a dropped file and open AppConfig).
+        if (e.Args.Length > 0 && e.Args[0] == "--shell-ext")
+        {
+            System.Diagnostics.Debug.WriteLine($"Malformed --shell-ext invocation: {string.Join(' ', e.Args)}");
+            Current.Shutdown(2);
+            return;
+        }
+
         if (e.Args.Length != 0)
         {
             StandaloneFilePath = SystemHelper.EnsureAbsolutePath(e.Args[0]);

--- a/src/LEGUI/AppConfig.xaml
+++ b/src/LEGUI/AppConfig.xaml
@@ -35,8 +35,7 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="{DynamicResource TabAbout}">
-                <!-- Filled by Task 6.1 -->
-                <Grid />
+                <legui:AboutPanel />
             </TabItem>
         </TabControl>
     </Grid>

--- a/src/LEGUI/AppConfig.xaml
+++ b/src/LEGUI/AppConfig.xaml
@@ -1,88 +1,43 @@
-﻿<Window x:Class="LEGUI.AppConfig"
+<Window x:Class="LEGUI.AppConfig"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:legui="clr-namespace:LEGUI"
-        Title="LEGUI - " Height="315.811" Width="330.4"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:legui="clr-namespace:LEGUI"
+        Title="LEGUI - " SizeToContent="Height" MinWidth="420" Width="420"
         WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
     <Grid TextElement.FontFamily="{DynamicResource UIFont}">
-        <Grid x:Name="mainGrid">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="60" />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid x:Name="appConfigGrid" Grid.Row="0" Background="#FFF1F1F1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="1*" />
-                    <RowDefinition Height="1*" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                </Grid.ColumnDefinitions>
-                <legui:MaskedTextBox x:Name="tbAppParameter" Grid.Row="0" Grid.Column="0" Height="Auto"
-                                     Margin="3,3,3,4" MaskText="{StaticResource EnterArgument}"
-                                     VerticalContentAlignment="Center" Grid.ColumnSpan="3" />
-                <Button x:Name="bSaveAppSetting" Grid.Row="1" Grid.Column="0" Content="{DynamicResource Save}"
-                        Margin="3,0,3,5" Click="bSaveAppSetting_Click" />
-                <Button x:Name="bShortcut" Grid.Row="1" Grid.Column="1" Content="{DynamicResource Shortcut}"
-                        Margin="3,0,3,5" Click="bShortcut_Click" />
-                <Button x:Name="bDeleteAppSetting" Grid.Row="1" Grid.Column="2" Content="{DynamicResource Delete}"
-                        Margin="3,0,3,5" Click="bDeleteAppSetting_Click" />
-            </Grid>
-            <Grid Grid.Row="1" Margin="0,0,0,10">
-                <Grid Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="1*" />
-                        <RowDefinition Height="1*" />
-                        <RowDefinition Height="2*" />
-                    </Grid.RowDefinitions>
-                    <GroupBox Grid.Row="0" Header="{DynamicResource LocationSettings}" Margin="4,0">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="32*" />
-                                <ColumnDefinition Width="69*" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Content="{DynamicResource Location}"
-                                   VerticalContentAlignment="Center" />
-                            <ComboBox x:Name="cbLocation" Grid.Column="1" Height="Auto" SelectedIndex="0" Margin="0,3" />
-                        </Grid>
-                    </GroupBox>
-                    <GroupBox Grid.Row="1" Header="{DynamicResource TimezoneSettings}" Margin="4,0">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="32*" />
-                                <ColumnDefinition Width="69*" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Row="0" Grid.Column="0" Content="{DynamicResource Timezone}"
-                                   VerticalContentAlignment="Center" />
-                            <ComboBox Grid.Row="0" Grid.Column="1" Height="Auto" x:Name="cbTimezone" SelectedIndex="0"
-                                      Margin="0,3" />
-                        </Grid>
-                    </GroupBox>
-                    <GroupBox Grid.Row="2" Header="{DynamicResource DebugOptions}" Margin="4,0">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                            </Grid.RowDefinitions>
-                            <CheckBox x:Name="cbStartAsAdmin" Grid.Row="0"
-                                      Content="{DynamicResource AsAdmin}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" />
-                            <CheckBox x:Name="cbRedirectRegistry" Grid.Row="1"
-                                      Content="{DynamicResource RedirectRegistry}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" IsChecked="True" />
-                            <CheckBox x:Name="cbIsAdvancedRedirection" Grid.Row="2"
-                                      Content="{DynamicResource IsAdvancedRedirection}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" IsChecked="false" />
-                            <CheckBox x:Name="cbStartAsSuspend" Grid.Row="3"
-                                      Content="{DynamicResource WithCREATESUSPENDED}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" />
-                        </Grid>
-                    </GroupBox>
-                </Grid>
-            </Grid>
-        </Grid>
+        <TabControl Margin="4" MinHeight="340">
+            <TabItem Header="{DynamicResource TabProfile}">
+                <DockPanel Margin="4">
+                    <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <legui:MaskedTextBox x:Name="tbAppParameter" Grid.Row="0" Grid.ColumnSpan="3"
+                                             MaskText="{StaticResource EnterArgument}"
+                                             VerticalContentAlignment="Center" Margin="3,3,3,4" />
+                        <Button x:Name="bSaveAppSetting" Grid.Row="1" Grid.Column="0"
+                                Content="{DynamicResource Save}" Margin="3,0,3,5"
+                                Click="bSaveAppSetting_Click" />
+                        <Button x:Name="bShortcut" Grid.Row="1" Grid.Column="1"
+                                Content="{DynamicResource Shortcut}" Margin="3,0,3,5"
+                                Click="bShortcut_Click" />
+                        <Button x:Name="bDeleteAppSetting" Grid.Row="1" Grid.Column="2"
+                                Content="{DynamicResource Delete}" Margin="3,0,3,5"
+                                Click="bDeleteAppSetting_Click" />
+                    </Grid>
+                    <legui:ProfileEditorControl x:Name="profileEditor" ShowDisplayOptions="False" />
+                </DockPanel>
+            </TabItem>
+            <TabItem Header="{DynamicResource TabAbout}">
+                <!-- Filled by Task 6.1 -->
+                <Grid />
+            </TabItem>
+        </TabControl>
     </Grid>
 </Window>

--- a/src/LEGUI/AppConfig.xaml
+++ b/src/LEGUI/AppConfig.xaml
@@ -2,10 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:legui="clr-namespace:LEGUI"
-        Title="LEGUI - " SizeToContent="Height" MinWidth="420" Width="420"
+        Title="LEGUI - " Width="420" Height="440"
         WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
     <Grid TextElement.FontFamily="{DynamicResource UIFont}">
-        <TabControl Margin="4" MinHeight="340">
+        <TabControl Margin="4">
             <TabItem Header="{DynamicResource TabProfile}">
                 <DockPanel Margin="4">
                     <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">

--- a/src/LEGUI/AppConfig.xaml.cs
+++ b/src/LEGUI/AppConfig.xaml.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices.ComTypes;
@@ -10,64 +9,47 @@ using LECommonLibrary;
 
 namespace LEGUI;
 
-/// <summary>
-///     Interaction logic for AppConfig.xaml
-/// </summary>
 public partial class AppConfig
 {
-    private readonly List<CultureInfo> _cultureInfos = new List<CultureInfo>();
-    private readonly List<TimeZoneInfo> _timezones = new List<TimeZoneInfo>();
-
     public AppConfig()
     {
         InitializeComponent();
 
         Title += Path.GetFileName(App.StandaloneFilePath).Replace(".le.config", "");
 
-        // Region.
-        _cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures).OrderBy(i => i.DisplayName).ToList();
-        cbLocation.ItemsSource = _cultureInfos.Select(c => c.DisplayName);
-        cbLocation.SelectedIndex = _cultureInfos.FindIndex(c => c.Name == "ja-JP");
-
-        //Timezone.
-        _timezones = TimeZoneInfo.GetSystemTimeZones().ToList();
-        cbTimezone.ItemsSource = _timezones.Select(t => t.DisplayName);
-        cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == "Tokyo Standard Time");
-
-        // Load exists config.
+        // Load existing config or fall back to default.
         var configs = LEConfig.GetProfiles(App.StandaloneFilePath);
+        LEProfile initial;
         if (configs.Length > 0)
         {
-            var conf = configs[0];
-
-            if (!string.IsNullOrEmpty(conf.Parameter))
+            initial = configs[0];
+            if (!string.IsNullOrEmpty(initial.Parameter))
             {
                 tbAppParameter.FontStyle = FontStyles.Normal;
-                tbAppParameter.Text = conf.Parameter;
+                tbAppParameter.Text = initial.Parameter;
             }
-            cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == conf.Timezone);
-            cbLocation.SelectedIndex = _cultureInfos.FindIndex(ci => ci.Name == conf.Location);
-
-            cbStartAsAdmin.IsChecked = conf.RunAsAdmin;
-            cbRedirectRegistry.IsChecked = conf.RedirectRegistry;
-            cbIsAdvancedRedirection.IsChecked = conf.IsAdvancedRedirection;
-            cbStartAsSuspend.IsChecked = conf.RunWithSuspend;
         }
+        else
+        {
+            initial = new LEProfile(true);
+        }
+
+        profileEditor.LoadProfile(initial);
     }
 
     private void SaveSetting()
     {
-        var crt = new LEProfile(Path.GetFileName(App.StandaloneFilePath),
-                                Guid.NewGuid().ToString(),
-                                false,
-                                tbAppParameter.Text,
-                                _cultureInfos[cbLocation.SelectedIndex].Name,
-                                _timezones[cbTimezone.SelectedIndex].Id,
-                                cbStartAsAdmin.IsChecked != null && (bool)cbStartAsAdmin.IsChecked,
-                                cbRedirectRegistry.IsChecked != null && (bool)cbRedirectRegistry.IsChecked,
-                                cbIsAdvancedRedirection.IsChecked != null && (bool)cbIsAdvancedRedirection.IsChecked,
-                                cbStartAsSuspend.IsChecked != null && (bool)cbStartAsSuspend.IsChecked
-            );
+        var template = new LEProfile(
+            Path.GetFileName(App.StandaloneFilePath),
+            Guid.NewGuid().ToString(),
+            false, // ShowInMainMenu — preserved by ReadProfile because ShowDisplayOptions=false
+            tbAppParameter.Text,
+            "ja-JP", "Tokyo Standard Time",
+            false, false, false, false);
+
+        var crt = profileEditor.ReadProfile(template);
+        // Parameter is owned by this window (not by editor), so re-assert it.
+        crt.Parameter = tbAppParameter.Text;
 
         LEConfig.SaveApplicationConfigFile(App.StandaloneFilePath, crt);
     }
@@ -78,54 +60,55 @@ public partial class AppConfig
         {
             var link = (IShellLink)new ShellLink();
 
-            link.SetPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                                      "LEProc.exe"));
+            link.SetPath(Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "LEProc.exe"));
             link.SetArguments($"-run \"{path}\"");
-            link.SetIconLocation(AssociationReader.GetAssociatedIcon(Path.GetExtension(path)).Replace("%1", path), 0);
-
+            link.SetIconLocation(
+                AssociationReader.GetAssociatedIcon(Path.GetExtension(path)).Replace("%1", path), 0);
             link.SetDescription($"Run {Path.GetFileName(path)} with Locale Emulator");
             link.SetWorkingDirectory(Path.GetDirectoryName(path));
 
             var file = (IPersistFile)link;
             file.Save(
-                      Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
-                                   Path.GetFileNameWithoutExtension(path) + ".lnk"),
-                      false);
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
+                    Path.GetFileNameWithoutExtension(path) + ".lnk"),
+                false);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            MessageBox.Show(e.Message + "\r\n\r\n" + e.StackTrace);
+            MessageBox.Show(ex.Message + "\r\n\r\n" + ex.StackTrace, "Locale Emulator");
         }
     }
 
     private void RunAndShutdown()
     {
-        //Run the application.
-        Process.Start(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "LEProc.exe"),
-                      $"-run \"{App.StandaloneFilePath.Replace(".le.config", "")}\"");
-
+        Process.Start(
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "LEProc.exe"),
+            $"-run \"{App.StandaloneFilePath.Replace(".le.config", "")}\"");
         Application.Current.Shutdown();
     }
 
     private void bSaveAppSetting_Click(object sender, RoutedEventArgs e)
     {
         SaveSetting();
-
         RunAndShutdown();
     }
 
     private void bShortcut_Click(object sender, RoutedEventArgs e)
     {
         SaveSetting();
-
         CreateShortcut(App.StandaloneFilePath.Replace(".le.config", ""));
-
         RunAndShutdown();
     }
 
     private void bDeleteAppSetting_Click(object sender, RoutedEventArgs e)
     {
-        if (MessageBoxResult.No == MessageBox.Show(I18n.GetString("ConfirmDel"), "", MessageBoxButton.YesNo))
+        if (MessageBoxResult.No == MessageBox.Show(
+            I18n.GetString("ConfirmDel"),
+            "Locale Emulator",
+            MessageBoxButton.YesNo))
             return;
 
         if (File.Exists(App.StandaloneFilePath))

--- a/src/LEGUI/AppConfig.xaml.cs
+++ b/src/LEGUI/AppConfig.xaml.cs
@@ -48,9 +48,6 @@ public partial class AppConfig
             false, false, false, false);
 
         var crt = profileEditor.ReadProfile(template);
-        // Parameter is owned by this window (not by editor), so re-assert it.
-        crt.Parameter = tbAppParameter.Text;
-
         LEConfig.SaveApplicationConfigFile(App.StandaloneFilePath, crt);
     }
 

--- a/src/LEGUI/AppConfig.xaml.cs
+++ b/src/LEGUI/AppConfig.xaml.cs
@@ -39,13 +39,20 @@ public partial class AppConfig
 
     private void SaveSetting()
     {
+        // ReadProfile overwrites every editable field from UI, so only Name / Guid /
+        // Parameter / (and ShowInMainMenu, which stays false thanks to
+        // ShowDisplayOptions=false on the editor) are actually consumed from this
+        // template. The remaining fields take LEProfile's defaults as harmless
+        // placeholders in case LoadProfile was never called and an index is -1.
+        var defaults = new LEProfile(true);
         var template = new LEProfile(
             Path.GetFileName(App.StandaloneFilePath),
             Guid.NewGuid().ToString(),
-            false, // ShowInMainMenu — preserved by ReadProfile because ShowDisplayOptions=false
+            defaults.ShowInMainMenu,
             tbAppParameter.Text,
-            "ja-JP", "Tokyo Standard Time",
-            false, false, false, false);
+            defaults.Location, defaults.Timezone,
+            defaults.RunAsAdmin, defaults.RedirectRegistry,
+            defaults.IsAdvancedRedirection, defaults.RunWithSuspend);
 
         var crt = profileEditor.ReadProfile(template);
         LEConfig.SaveApplicationConfigFile(App.StandaloneFilePath, crt);

--- a/src/LEGUI/GlobalConfig.xaml
+++ b/src/LEGUI/GlobalConfig.xaml
@@ -38,8 +38,7 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="{DynamicResource TabShellExtension}">
-                <!-- Filled by Task 4.2 -->
-                <Grid />
+                <legui:ShellExtensionPanel x:Name="shellExtPanel" />
             </TabItem>
             <TabItem Header="{DynamicResource TabAbout}">
                 <!-- Filled by Task 6.1 -->

--- a/src/LEGUI/GlobalConfig.xaml
+++ b/src/LEGUI/GlobalConfig.xaml
@@ -1,100 +1,50 @@
-﻿<Window x:Class="LEGUI.GlobalConfig"
+<Window x:Class="LEGUI.GlobalConfig"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="LEGUI GLOBAL" Height="377.16" Width="310"
+        xmlns:legui="clr-namespace:LEGUI"
+        Title="LEGUI GLOBAL" SizeToContent="Height" MinWidth="420" Width="420"
         WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
-    <Grid TextElement.FontFamily="{DynamicResource UIFont}">
-        <Grid x:Name="mainGrid">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="60" />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid x:Name="globalConfigGrid" Grid.Row="0" Background="#FFF1F1F1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="1*" />
-                    <RowDefinition Height="1*" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                </Grid.ColumnDefinitions>
-                <ComboBox SelectedIndex="0" x:Name="cbGlobalProfiles" Grid.Row="0" Grid.Column="0" Height="Auto"
-                          Margin="3,3,3,4"
-                          VerticalContentAlignment="Center" Grid.ColumnSpan="3"
-                          SelectionChanged="cbGlobalProfiles_SelectionChanged" />
-                <Button x:Name="bSaveGlobalSetting" Grid.Row="1" Grid.Column="0" Content="{DynamicResource Save}"
-                        Margin="3,0,3,5" Click="bSaveGlobalSetting_Click" />
-                <Button x:Name="bSaveGlobalSettingAs" Grid.Row="1" Grid.Column="1" Content="{DynamicResource SaveAs}"
-                        Margin="3,0,3,5" Click="bSaveGlobalSettingAs_Click" />
-                <Button x:Name="bDeleteGlobalSetting" Grid.Row="1" Grid.Column="2" Content="{DynamicResource Delete}"
-                        Margin="3,0,3,5" Click="bDeleteGlobalSetting_Click" />
-            </Grid>
-            <Grid Grid.Row="1" Margin="0,0,0,10">
-                <Grid Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="1*" />
-                        <RowDefinition Height="1*" />
-                        <RowDefinition Height="2*" />
-                        <RowDefinition Height="1*" />
-                    </Grid.RowDefinitions>
-                    <GroupBox Grid.Row="0" Header="{DynamicResource LocationSettings}" Margin="4,0">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="101*" />
-                                <ColumnDefinition Width="167*" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Content="{DynamicResource Location}"
-                                   VerticalContentAlignment="Center" />
-                            <ComboBox x:Name="cbLocation" Grid.Column="1" Height="Auto" SelectedIndex="0" Margin="0,3" />
-                        </Grid>
-                    </GroupBox>
-                    <GroupBox Grid.Row="1" Header="{DynamicResource TimezoneSettings}" Margin="4,0">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="101*" />
-                                <ColumnDefinition Width="167*" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Row="0" Grid.Column="0" Content="{DynamicResource Timezone}"
-                                   VerticalContentAlignment="Center" />
-                            <ComboBox Grid.Row="0" Grid.Column="1" Height="Auto" x:Name="cbTimezone" SelectedIndex="0"
-                                      Margin="0,3" />
-                        </Grid>
-                    </GroupBox>
-                    <GroupBox Grid.Row="2" Header="{DynamicResource DebugOptions}" Margin="4,0">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                                <RowDefinition Height="1*" />
-                            </Grid.RowDefinitions>
-                            <CheckBox x:Name="cbStartAsAdmin" Grid.Row="0"
-                                      Content="{DynamicResource AsAdmin}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" />
-                            <CheckBox x:Name="cbRedirectRegistry" Grid.Row="1"
-                                      Content="{DynamicResource RedirectRegistry}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" IsChecked="True" />
-                            <CheckBox x:Name="cbIsAdvancedRedirection" Grid.Row="2"
-                                      Content="{DynamicResource IsAdvancedRedirection}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" IsChecked="false" />
-                            <CheckBox x:Name="cbStartAsSuspend" Grid.Row="3"
-                                      Content="{DynamicResource WithCREATESUSPENDED}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" />
-                        </Grid>
-                    </GroupBox>
-                    <GroupBox Grid.Row="3" Header="{DynamicResource Miscellaneous}" Margin="4,0">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <CheckBox x:Name="cbShowInMainMenu" Grid.Row="0"
-                                      Content="{DynamicResource ShowInMainMenu}" Margin="5,0,0,0"
-                                      VerticalAlignment="Center" />
-                        </Grid>
-                    </GroupBox>
-                </Grid>
-            </Grid>
-        </Grid>
-    </Grid>
+    <DockPanel TextElement.FontFamily="{DynamicResource UIFont}">
+        <StatusBar x:Name="statusBar" DockPanel.Dock="Bottom" Height="22">
+            <StatusBarItem><TextBlock x:Name="statusText" /></StatusBarItem>
+        </StatusBar>
+        <TabControl Margin="4" MinHeight="380">
+            <TabItem Header="{DynamicResource TabProfile}">
+                <DockPanel Margin="4">
+                    <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <ComboBox x:Name="cbGlobalProfiles" Grid.Row="0" Grid.ColumnSpan="3"
+                                  VerticalContentAlignment="Center" Margin="3,3,3,4"
+                                  SelectionChanged="cbGlobalProfiles_SelectionChanged" />
+                        <Button x:Name="bSaveGlobalSetting" Grid.Row="1" Grid.Column="0"
+                                Content="{DynamicResource Save}" Margin="3,0,3,5"
+                                Click="bSaveGlobalSetting_Click" />
+                        <Button x:Name="bSaveGlobalSettingAs" Grid.Row="1" Grid.Column="1"
+                                Content="{DynamicResource SaveAs}" Margin="3,0,3,5"
+                                Click="bSaveGlobalSettingAs_Click" />
+                        <Button x:Name="bDeleteGlobalSetting" Grid.Row="1" Grid.Column="2"
+                                Content="{DynamicResource Delete}" Margin="3,0,3,5"
+                                Click="bDeleteGlobalSetting_Click" />
+                    </Grid>
+                    <legui:ProfileEditorControl x:Name="profileEditor" />
+                </DockPanel>
+            </TabItem>
+            <TabItem Header="{DynamicResource TabShellExtension}">
+                <!-- Filled by Task 4.2 -->
+                <Grid />
+            </TabItem>
+            <TabItem Header="{DynamicResource TabAbout}">
+                <!-- Filled by Task 6.1 -->
+                <Grid />
+            </TabItem>
+        </TabControl>
+    </DockPanel>
 </Window>

--- a/src/LEGUI/GlobalConfig.xaml
+++ b/src/LEGUI/GlobalConfig.xaml
@@ -41,8 +41,7 @@
                 <legui:ShellExtensionPanel x:Name="shellExtPanel" />
             </TabItem>
             <TabItem Header="{DynamicResource TabAbout}">
-                <!-- Filled by Task 6.1 -->
-                <Grid />
+                <legui:AboutPanel />
             </TabItem>
         </TabControl>
     </DockPanel>

--- a/src/LEGUI/GlobalConfig.xaml
+++ b/src/LEGUI/GlobalConfig.xaml
@@ -2,13 +2,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:legui="clr-namespace:LEGUI"
-        Title="LEGUI GLOBAL" SizeToContent="Height" MinWidth="420" Width="420"
+        Title="LEGUI GLOBAL" Width="420" Height="470"
         WindowStartupLocation="CenterScreen" ResizeMode="CanMinimize">
-    <DockPanel TextElement.FontFamily="{DynamicResource UIFont}">
-        <StatusBar x:Name="statusBar" DockPanel.Dock="Bottom" Height="22">
-            <StatusBarItem><TextBlock x:Name="statusText" /></StatusBarItem>
-        </StatusBar>
-        <TabControl Margin="4" MinHeight="380">
+    <Grid TextElement.FontFamily="{DynamicResource UIFont}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TabControl Grid.Row="0" Margin="4">
             <TabItem Header="{DynamicResource TabProfile}">
                 <DockPanel Margin="4">
                     <Grid DockPanel.Dock="Top" Height="60" Background="#FFF1F1F1" Margin="0,0,0,6">
@@ -44,5 +45,8 @@
                 <legui:AboutPanel />
             </TabItem>
         </TabControl>
-    </DockPanel>
+        <StatusBar x:Name="statusBar" Grid.Row="1" Height="22">
+            <StatusBarItem><TextBlock x:Name="statusText" /></StatusBarItem>
+        </StatusBar>
+    </Grid>
 </Window>

--- a/src/LEGUI/GlobalConfig.xaml.cs
+++ b/src/LEGUI/GlobalConfig.xaml.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -25,6 +26,24 @@ public partial class GlobalConfig
             statusText.Text = string.Empty;
             _statusClearTimer.Stop();
         };
+
+        InitializeShellExtPanel();
+    }
+
+    private void InitializeShellExtPanel()
+    {
+        var processPath = Environment.ProcessPath;
+        var basePath = !string.IsNullOrEmpty(processPath)
+            ? Path.GetDirectoryName(Path.GetDirectoryName(processPath))
+            : AppContext.BaseDirectory;
+
+        var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+        var registrar = new ShellExtensionRegistrar(
+            new RegistryOperations(),
+            ShellExtensionConstants.NewClsid);
+
+        shellExtPanel.SetCommand(registrar, dllPath, SystemHelper.IsAdministrator());
+        shellExtPanel.RefreshStatus();
     }
 
     private void ShowSavedStatus()

--- a/src/LEGUI/GlobalConfig.xaml.cs
+++ b/src/LEGUI/GlobalConfig.xaml.cs
@@ -1,37 +1,37 @@
 #nullable disable
 
-using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media.Effects;
+using System.Windows.Threading;
 using LECommonLibrary;
 
 namespace LEGUI;
 
-/// <summary>
-///     Interaction logic for GlobalConfig.xaml
-/// </summary>
 public partial class GlobalConfig
 {
-    private readonly List<CultureInfo> _cultureInfos = new List<CultureInfo>();
-    private readonly List<LEProfile> _profiles = new List<LEProfile>();
-    private readonly List<TimeZoneInfo> _timezones = new List<TimeZoneInfo>();
+    private readonly List<LEProfile> _profiles;
+    private readonly DispatcherTimer _statusClearTimer;
 
     public GlobalConfig()
     {
         InitializeComponent();
 
-        // Region.
-        _cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures).OrderBy(i => i.DisplayName).ToList();
-        cbLocation.ItemsSource = _cultureInfos.Select(c => c.DisplayName);
-
-        //Timezone.
-        _timezones = TimeZoneInfo.GetSystemTimeZones().ToList();
-        cbTimezone.ItemsSource = _timezones.Select(t => t.DisplayName);
-
-        //Profiles.
         _profiles = LEConfig.GetProfiles().ToList();
         cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
+
+        _statusClearTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+        _statusClearTimer.Tick += (_, _) =>
+        {
+            statusText.Text = string.Empty;
+            _statusClearTimer.Stop();
+        };
+    }
+
+    private void ShowSavedStatus()
+    {
+        statusText.Text = I18n.GetString("SavedStatus");
+        _statusClearTimer.Stop();
+        _statusClearTimer.Start();
     }
 
     private void bSaveGlobalSetting_Click(object sender, RoutedEventArgs e)
@@ -39,20 +39,10 @@ public partial class GlobalConfig
         if (cbGlobalProfiles.Items.Count == 0)
             return;
 
-        var crt = _profiles[cbGlobalProfiles.SelectedIndex];
-        crt.Location = _cultureInfos[cbLocation.SelectedIndex].Name;
-        crt.Timezone = _timezones[cbTimezone.SelectedIndex].Id;
-        crt.ShowInMainMenu = cbShowInMainMenu.IsChecked != null && (bool)cbShowInMainMenu.IsChecked;
-
-        crt.RunAsAdmin = cbStartAsAdmin.IsChecked != null && (bool)cbStartAsAdmin.IsChecked;
-        crt.RedirectRegistry = cbRedirectRegistry.IsChecked != null && (bool)cbRedirectRegistry.IsChecked;
-        crt.IsAdvancedRedirection = cbIsAdvancedRedirection.IsChecked != null
-                                    && (bool)cbIsAdvancedRedirection.IsChecked;
-        crt.RunWithSuspend = cbStartAsSuspend.IsChecked != null && (bool)cbStartAsSuspend.IsChecked;
-
-        _profiles[cbGlobalProfiles.SelectedIndex] = crt;
-
+        var idx = cbGlobalProfiles.SelectedIndex;
+        _profiles[idx] = profileEditor.ReadProfile(_profiles[idx]);
         LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
+        ShowSavedStatus();
     }
 
     private void cbGlobalProfiles_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -61,63 +51,43 @@ public partial class GlobalConfig
         bSaveGlobalSetting.IsEnabled = cbGlobalProfiles.Items.Count != 0;
 
         if (cbGlobalProfiles.SelectedIndex == -1)
-        {
             return;
-        }
 
-        var crt = _profiles[cbGlobalProfiles.SelectedIndex];
-
-        cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == crt.Timezone);
-        cbLocation.SelectedIndex = _cultureInfos.FindIndex(ci => ci.Name == crt.Location);
-
-        cbShowInMainMenu.IsChecked = crt.ShowInMainMenu;
-        cbStartAsAdmin.IsChecked = crt.RunAsAdmin;
-        cbRedirectRegistry.IsChecked = crt.RedirectRegistry;
-        cbIsAdvancedRedirection.IsChecked = crt.IsAdvancedRedirection;
-        cbStartAsSuspend.IsChecked = crt.RunWithSuspend;
+        profileEditor.LoadProfile(_profiles[cbGlobalProfiles.SelectedIndex]);
     }
 
     private void bSaveGlobalSettingAs_Click(object sender, RoutedEventArgs e)
     {
-        mainGrid.Effect = new BlurEffect();
-
         var ib = new InputBox
-                 {
-                     Owner = this,
-                     WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                     Instruction = I18n.GetString("SaveAsInstruction"),
-                     OkText = I18n.GetString("Save"),
-                     CancelText = I18n.GetString("Cancel")
-                 };
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Instruction = I18n.GetString("SaveAsInstruction"),
+            OkText = I18n.GetString("Save"),
+            CancelText = I18n.GetString("Cancel")
+        };
 
         if (ib.ShowDialog() == true && !string.IsNullOrEmpty(ib.Text))
         {
             SaveProfileAs(ib.Text);
-
             cbGlobalProfiles.SelectedIndex = _profiles.Count - 1;
+            ShowSavedStatus();
         }
-
-        mainGrid.Effect = null;
     }
 
     private void SaveProfileAs(string name)
     {
-        var pro = new LEProfile(name,
-                                Guid.NewGuid().ToString(),
-                                cbShowInMainMenu.IsChecked != null && (bool)cbShowInMainMenu.IsChecked,
-                                string.Empty,
-                                _cultureInfos[cbLocation.SelectedIndex].Name,
-                                _timezones[cbTimezone.SelectedIndex].Id,
-                                cbStartAsAdmin.IsChecked != null && (bool)cbStartAsAdmin.IsChecked,
-                                cbRedirectRegistry.IsChecked != null && (bool)cbRedirectRegistry.IsChecked,
-                                cbIsAdvancedRedirection.IsChecked != null && (bool)cbIsAdvancedRedirection.IsChecked,
-                                cbStartAsSuspend.IsChecked != null && (bool)cbStartAsSuspend.IsChecked);
+        // Build template preserving outer-owned fields (Name/Guid/Parameter).
+        // Name uses user-provided text; Guid is freshly generated.
+        var baseProfile = cbGlobalProfiles.SelectedIndex >= 0
+            ? _profiles[cbGlobalProfiles.SelectedIndex]
+            : new LEProfile(true);
+        baseProfile.Name = name;
+        baseProfile.Guid = Guid.NewGuid().ToString();
+        var created = profileEditor.ReadProfile(baseProfile);
 
-        _profiles.Add(pro);
-
+        _profiles.Add(created);
         LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
-
-        // Update cbGlobalProfiles.
         cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
     }
 
@@ -126,14 +96,14 @@ public partial class GlobalConfig
         if (cbGlobalProfiles.SelectedIndex == -1)
             return;
 
-        if (MessageBoxResult.No == MessageBox.Show(I18n.GetString("ConfirmDel"), "", MessageBoxButton.YesNo))
+        if (MessageBoxResult.No == MessageBox.Show(
+            I18n.GetString("ConfirmDel"),
+            "Locale Emulator",
+            MessageBoxButton.YesNo))
             return;
 
         _profiles.RemoveAt(cbGlobalProfiles.SelectedIndex);
-
         LEConfig.SaveGlobalConfigFile(_profiles.ToArray());
-
-        // Update cbGlobalProfiles.
         cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
         cbGlobalProfiles.SelectedIndex = 0;
     }

--- a/src/LEGUI/GlobalConfig.xaml.cs
+++ b/src/LEGUI/GlobalConfig.xaml.cs
@@ -19,6 +19,10 @@ public partial class GlobalConfig
 
         _profiles = LEConfig.GetProfiles().ToList();
         cbGlobalProfiles.ItemsSource = _profiles.Select(p => p.Name);
+        if (_profiles.Count > 0)
+            cbGlobalProfiles.SelectedIndex = 0;     // triggers LoadProfile via SelectionChanged
+        else
+            profileEditor.LoadProfile(new LEProfile(true));
 
         _statusClearTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
         _statusClearTimer.Tick += (_, _) =>

--- a/src/LEGUI/GlobalConfig.xaml.cs
+++ b/src/LEGUI/GlobalConfig.xaml.cs
@@ -33,9 +33,11 @@ public partial class GlobalConfig
     private void InitializeShellExtPanel()
     {
         var processPath = Environment.ProcessPath;
-        var basePath = !string.IsNullOrEmpty(processPath)
-            ? Path.GetDirectoryName(Path.GetDirectoryName(processPath))
-            : AppContext.BaseDirectory;
+        string basePath = null;
+        if (!string.IsNullOrEmpty(processPath))
+            basePath = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
+        if (string.IsNullOrEmpty(basePath))
+            basePath = AppContext.BaseDirectory;
 
         var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
         var registrar = new ShellExtensionRegistrar(

--- a/src/LEGUI/GlobalConfig.xaml.cs
+++ b/src/LEGUI/GlobalConfig.xaml.cs
@@ -36,14 +36,8 @@ public partial class GlobalConfig
 
     private void InitializeShellExtPanel()
     {
-        var processPath = Environment.ProcessPath;
-        string basePath = null;
-        if (!string.IsNullOrEmpty(processPath))
-            basePath = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
-        if (string.IsNullOrEmpty(basePath))
-            basePath = AppContext.BaseDirectory;
-
-        var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(basePath);
+        var dllPath = ShellExtensionRegistrar.AutoDetectDllPath(
+            ShellExtensionRegistrar.GetBuildOutputRoot());
         var registrar = new ShellExtensionRegistrar(
             new RegistryOperations(),
             ShellExtensionConstants.NewClsid);

--- a/src/LEGUI/I18n.cs
+++ b/src/LEGUI/I18n.cs
@@ -46,21 +46,18 @@ internal class I18n
             var fallbackLangPath = Path.Combine(langDir,
                                                 $@"{CurrentCultureInfo.TwoLetterISOLanguageName}.xaml");
 
+            // Append (not Insert at 0): WPF MergedDictionaries lookup walks in
+            // reverse index order, so the last-added dictionary takes priority.
+            // We want the locale dictionary to win over DefaultLanguage.xaml.
             if (File.Exists(firstLangPath))
             {
                 using var stream = new FileStream(firstLangPath, FileMode.Open);
-                // Append (not Insert at 0): WPF MergedDictionaries lookup walks in
-                // reverse index order, so the last-added dictionary takes priority.
-                // We want the locale dictionary to win over DefaultLanguage.xaml.
                 Application.Current.Resources.MergedDictionaries
                            .Add(XamlReader.Load(stream) as ResourceDictionary);
             }
             else if (File.Exists(fallbackLangPath))
             {
                 using var stream = new FileStream(fallbackLangPath, FileMode.Open);
-                // Append (not Insert at 0): WPF MergedDictionaries lookup walks in
-                // reverse index order, so the last-added dictionary takes priority.
-                // We want the locale dictionary to win over DefaultLanguage.xaml.
                 Application.Current.Resources.MergedDictionaries
                            .Add(XamlReader.Load(stream) as ResourceDictionary);
             }

--- a/src/LEGUI/I18n.cs
+++ b/src/LEGUI/I18n.cs
@@ -49,26 +49,34 @@ internal class I18n
             if (File.Exists(firstLangPath))
             {
                 using var stream = new FileStream(firstLangPath, FileMode.Open);
+                // Append (not Insert at 0): WPF MergedDictionaries lookup walks in
+                // reverse index order, so the last-added dictionary takes priority.
+                // We want the locale dictionary to win over DefaultLanguage.xaml.
                 Application.Current.Resources.MergedDictionaries
-                           .Insert(0, XamlReader.Load(stream) as ResourceDictionary);
+                           .Add(XamlReader.Load(stream) as ResourceDictionary);
             }
             else if (File.Exists(fallbackLangPath))
             {
                 using var stream = new FileStream(fallbackLangPath, FileMode.Open);
+                // Append (not Insert at 0): WPF MergedDictionaries lookup walks in
+                // reverse index order, so the last-added dictionary takes priority.
+                // We want the locale dictionary to win over DefaultLanguage.xaml.
                 Application.Current.Resources.MergedDictionaries
-                           .Insert(0, XamlReader.Load(stream) as ResourceDictionary);
+                           .Add(XamlReader.Load(stream) as ResourceDictionary);
             }
         }
         catch
         {
         }
 
-        //If dictionary is still null, use default language.
-        if (dictionary == null)
-            if (Application.Current.Resources.MergedDictionaries.Count > 0)
-                dictionary = Application.Current.Resources.MergedDictionaries[0];
-            else
-                throw new Exception("No language file.");
+        // Pick the highest-priority dictionary (last in MergedDictionaries — locale if
+        // available, otherwise DefaultLanguage). This cached reference is used by
+        // GetString for direct key lookup; DynamicResource lookups on UI elements
+        // walk the whole MergedDictionaries chain on their own.
+        var merged = Application.Current.Resources.MergedDictionaries;
+        if (merged.Count == 0)
+            throw new Exception("No language file.");
+        dictionary = merged[merged.Count - 1];
 
         cacheDictionary = dictionary;
 
@@ -77,9 +85,11 @@ internal class I18n
 
     internal static void LoadLanguage()
     {
-        var dict = LoadDictionary();
-
-        Application.Current.Resources.MergedDictionaries.Clear();
-        Application.Current.Resources.MergedDictionaries.Add(dict);
+        // Eagerly trigger the locale dictionary load so UI elements bound with
+        // {DynamicResource ...} resolve correctly on first render. We no longer
+        // replace MergedDictionaries wholesale — DefaultLanguage.xaml (declared in
+        // App.xaml) must remain as fallback so keys present only in the default
+        // dictionary still resolve when a locale file lacks them.
+        LoadDictionary();
     }
 }

--- a/src/LEGUI/I18n.cs
+++ b/src/LEGUI/I18n.cs
@@ -16,9 +16,9 @@ internal class I18n
 
     internal static string GetString(string key)
     {
-        var dict = LoadDictionary();
         try
         {
+            var dict = LoadDictionary();
             var s = (string)dict[key];
 
             if (string.IsNullOrEmpty(s))

--- a/src/LEGUI/IShellExtensionQuery.cs
+++ b/src/LEGUI/IShellExtensionQuery.cs
@@ -1,0 +1,7 @@
+namespace LEGUI;
+
+public interface IShellExtensionQuery
+{
+    bool IsInstalled(ShellExtensionRegistrar.InstallMode mode);
+    bool HasOldRegistration();
+}

--- a/src/LEGUI/IShellExtensionQuery.cs
+++ b/src/LEGUI/IShellExtensionQuery.cs
@@ -5,3 +5,10 @@ public interface IShellExtensionQuery
     bool IsInstalled(ShellExtensionRegistrar.InstallMode mode);
     bool HasOldRegistration();
 }
+
+public interface IShellExtensionCommand : IShellExtensionQuery
+{
+    void Register(ShellExtensionRegistrar.InstallMode mode, string dllPath);
+    void Unregister(ShellExtensionRegistrar.InstallMode mode);
+    void CleanupOldRegistration();
+}

--- a/src/LEGUI/Lang/DefaultLanguage.xaml
+++ b/src/LEGUI/Lang/DefaultLanguage.xaml
@@ -44,4 +44,5 @@
     <system:String x:Key="ShellExtAllUsersHeader">All Users &#x1F6E1;</system:String>
     <system:String x:Key="ShellExtOldResidueDetected">&#x26A0; Old version residue detected</system:String>
     <system:String x:Key="ShellExtCleanupOld">Clean up old registration</system:String>
+    <system:String x:Key="ShellExtOperationFailed">Shell Extension operation failed: {0}</system:String>
 </ResourceDictionary>

--- a/src/LEGUI/Lang/DefaultLanguage.xaml
+++ b/src/LEGUI/Lang/DefaultLanguage.xaml
@@ -40,4 +40,8 @@
     <system:String x:Key="TabShellExtension">Shell Extension</system:String>
     <system:String x:Key="TabAbout">About</system:String>
     <system:String x:Key="SavedStatus">Saved</system:String>
+    <system:String x:Key="ShellExtCurrentUserHeader">Current User</system:String>
+    <system:String x:Key="ShellExtAllUsersHeader">All Users &#x1F6E1;</system:String>
+    <system:String x:Key="ShellExtOldResidueDetected">&#x26A0; Old version residue detected</system:String>
+    <system:String x:Key="ShellExtCleanupOld">Clean up old registration</system:String>
 </ResourceDictionary>

--- a/src/LEGUI/Lang/DefaultLanguage.xaml
+++ b/src/LEGUI/Lang/DefaultLanguage.xaml
@@ -36,4 +36,8 @@
     <system:String x:Key="IsAdvancedRedirectionTip">Also redirect Registry keys that control system UI language, affecting some apps that query via MUI_LANGUAGE_NAME.</system:String>
     <system:String x:Key="WithCREATESUSPENDEDTip">Create the target process in suspended state (advanced debugging option).</system:String>
     <system:String x:Key="ShowInMainMenuTip">Display this profile directly in the right-click menu root instead of under a submenu.</system:String>
+    <system:String x:Key="TabProfile">Profile</system:String>
+    <system:String x:Key="TabShellExtension">Shell Extension</system:String>
+    <system:String x:Key="TabAbout">About</system:String>
+    <system:String x:Key="SavedStatus">Saved</system:String>
 </ResourceDictionary>

--- a/src/LEGUI/Lang/DefaultLanguage.xaml
+++ b/src/LEGUI/Lang/DefaultLanguage.xaml
@@ -30,4 +30,5 @@
     <system:String x:Key="InstallStatus">Status:</system:String>
     <system:String x:Key="Installed">Installed</system:String>
     <system:String x:Key="NotInstalled">Not Installed</system:String>
+    <system:String x:Key="Display">Display</system:String>
 </ResourceDictionary>

--- a/src/LEGUI/Lang/DefaultLanguage.xaml
+++ b/src/LEGUI/Lang/DefaultLanguage.xaml
@@ -18,7 +18,7 @@
     <system:String x:Key="AsAdmin">Run as administrator</system:String>
     <system:String x:Key="RedirectRegistry">Fake language-related keys in Registry</system:String>
     <system:String x:Key="IsAdvancedRedirection">Fake system UI language</system:String>
-    <system:String x:Key="WithCREATESUSPENDED">Create process with CREATE__SUSPENDED</system:String>
+    <system:String x:Key="WithCREATESUSPENDED">Create process with CREATE_SUSPENDED</system:String>
     <system:String x:Key="Miscellaneous">Miscellaneous</system:String>
     <system:String x:Key="ShowInMainMenu">Show this profile in main menu</system:String>
     <system:String x:Key="InstallSuccess">Shell Extension installed successfully. Please restart Explorer or log out to take effect.</system:String>
@@ -31,4 +31,9 @@
     <system:String x:Key="Installed">Installed</system:String>
     <system:String x:Key="NotInstalled">Not Installed</system:String>
     <system:String x:Key="Display">Display</system:String>
+    <system:String x:Key="AsAdminTip">Launch the target process with elevated privileges. Required for some games.</system:String>
+    <system:String x:Key="RedirectRegistryTip">Intercept Registry reads for locale-related keys, returning the emulated locale instead of the system's.</system:String>
+    <system:String x:Key="IsAdvancedRedirectionTip">Also redirect Registry keys that control system UI language, affecting some apps that query via MUI_LANGUAGE_NAME.</system:String>
+    <system:String x:Key="WithCREATESUSPENDEDTip">Create the target process in suspended state (advanced debugging option).</system:String>
+    <system:String x:Key="ShowInMainMenuTip">Display this profile directly in the right-click menu root instead of under a submenu.</system:String>
 </ResourceDictionary>

--- a/src/LEGUI/ProfileEditorControl.xaml
+++ b/src/LEGUI/ProfileEditorControl.xaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="LEGUI.ProfileEditorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid TextElement.FontFamily="{DynamicResource UIFont}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <GroupBox Grid.Row="0" Header="{DynamicResource LocationSettings}" Margin="4,2">
+            <ComboBox x:Name="cbLocation" Margin="4" />
+        </GroupBox>
+        <GroupBox Grid.Row="1" Header="{DynamicResource TimezoneSettings}" Margin="4,2">
+            <ComboBox x:Name="cbTimezone" Margin="4" />
+        </GroupBox>
+        <GroupBox Grid.Row="2" Header="{DynamicResource DebugOptions}" Margin="4,2">
+            <StackPanel Margin="4">
+                <CheckBox x:Name="cbStartAsAdmin" Content="{DynamicResource AsAdmin}" Margin="0,2" />
+                <CheckBox x:Name="cbRedirectRegistry" Content="{DynamicResource RedirectRegistry}" Margin="0,2" />
+                <CheckBox x:Name="cbIsAdvancedRedirection" Content="{DynamicResource IsAdvancedRedirection}" Margin="0,2" />
+                <CheckBox x:Name="cbStartAsSuspend" Content="{DynamicResource WithCREATESUSPENDED}" Margin="0,2" />
+            </StackPanel>
+        </GroupBox>
+        <GroupBox x:Name="displayGroup" Grid.Row="3" Header="{DynamicResource Display}" Margin="4,2">
+            <CheckBox x:Name="cbShowInMainMenu" Content="{DynamicResource ShowInMainMenu}" Margin="4" />
+        </GroupBox>
+    </Grid>
+</UserControl>

--- a/src/LEGUI/ProfileEditorControl.xaml
+++ b/src/LEGUI/ProfileEditorControl.xaml
@@ -16,14 +16,14 @@
         </GroupBox>
         <GroupBox Grid.Row="2" Header="{DynamicResource DebugOptions}" Margin="4,2">
             <StackPanel Margin="4">
-                <CheckBox x:Name="cbStartAsAdmin" Content="{DynamicResource AsAdmin}" Margin="0,2" />
-                <CheckBox x:Name="cbRedirectRegistry" Content="{DynamicResource RedirectRegistry}" Margin="0,2" />
-                <CheckBox x:Name="cbIsAdvancedRedirection" Content="{DynamicResource IsAdvancedRedirection}" Margin="0,2" />
-                <CheckBox x:Name="cbStartAsSuspend" Content="{DynamicResource WithCREATESUSPENDED}" Margin="0,2" />
+                <CheckBox x:Name="cbStartAsAdmin" Content="{DynamicResource AsAdmin}" ToolTip="{DynamicResource AsAdminTip}" Margin="0,2" />
+                <CheckBox x:Name="cbRedirectRegistry" Content="{DynamicResource RedirectRegistry}" ToolTip="{DynamicResource RedirectRegistryTip}" Margin="0,2" />
+                <CheckBox x:Name="cbIsAdvancedRedirection" Content="{DynamicResource IsAdvancedRedirection}" ToolTip="{DynamicResource IsAdvancedRedirectionTip}" Margin="0,2" />
+                <CheckBox x:Name="cbStartAsSuspend" Content="{DynamicResource WithCREATESUSPENDED}" ToolTip="{DynamicResource WithCREATESUSPENDEDTip}" Margin="0,2" />
             </StackPanel>
         </GroupBox>
         <GroupBox x:Name="displayGroup" Grid.Row="3" Header="{DynamicResource Display}" Margin="4,2">
-            <CheckBox x:Name="cbShowInMainMenu" Content="{DynamicResource ShowInMainMenu}" Margin="4" />
+            <CheckBox x:Name="cbShowInMainMenu" Content="{DynamicResource ShowInMainMenu}" ToolTip="{DynamicResource ShowInMainMenuTip}" Margin="4" />
         </GroupBox>
     </Grid>
 </UserControl>

--- a/src/LEGUI/ProfileEditorControl.xaml.cs
+++ b/src/LEGUI/ProfileEditorControl.xaml.cs
@@ -1,0 +1,74 @@
+#nullable disable
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using LECommonLibrary;
+
+namespace LEGUI;
+
+public partial class ProfileEditorControl : UserControl
+{
+    private readonly List<CultureInfo> _cultureInfos;
+    private readonly List<TimeZoneInfo> _timezones;
+
+    public static readonly DependencyProperty ShowDisplayOptionsProperty =
+        DependencyProperty.Register(
+            nameof(ShowDisplayOptions),
+            typeof(bool),
+            typeof(ProfileEditorControl),
+            new PropertyMetadata(true, OnShowDisplayOptionsChanged));
+
+    public bool ShowDisplayOptions
+    {
+        get => (bool)GetValue(ShowDisplayOptionsProperty);
+        set => SetValue(ShowDisplayOptionsProperty, value);
+    }
+
+    public ProfileEditorControl()
+    {
+        InitializeComponent();
+
+        _cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .OrderBy(i => i.DisplayName).ToList();
+        cbLocation.ItemsSource = _cultureInfos.Select(c => c.DisplayName);
+
+        _timezones = TimeZoneInfo.GetSystemTimeZones().ToList();
+        cbTimezone.ItemsSource = _timezones.Select(t => t.DisplayName);
+    }
+
+    public void LoadProfile(LEProfile source)
+    {
+        cbLocation.SelectedIndex = _cultureInfos.FindIndex(ci => ci.Name == source.Location);
+        cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == source.Timezone);
+        cbStartAsAdmin.IsChecked = source.RunAsAdmin;
+        cbRedirectRegistry.IsChecked = source.RedirectRegistry;
+        cbIsAdvancedRedirection.IsChecked = source.IsAdvancedRedirection;
+        cbStartAsSuspend.IsChecked = source.RunWithSuspend;
+        cbShowInMainMenu.IsChecked = source.ShowInMainMenu;
+    }
+
+    public LEProfile ReadProfile(LEProfile template)
+    {
+        var locationIdx = cbLocation.SelectedIndex;
+        var timezoneIdx = cbTimezone.SelectedIndex;
+        return new LEProfile(
+            template.Name,
+            template.Guid,
+            ShowDisplayOptions ? cbShowInMainMenu.IsChecked == true : template.ShowInMainMenu,
+            template.Parameter,
+            locationIdx >= 0 ? _cultureInfos[locationIdx].Name : template.Location,
+            timezoneIdx >= 0 ? _timezones[timezoneIdx].Id : template.Timezone,
+            cbStartAsAdmin.IsChecked == true,
+            cbRedirectRegistry.IsChecked == true,
+            cbIsAdvancedRedirection.IsChecked == true,
+            cbStartAsSuspend.IsChecked == true);
+    }
+
+    private static void OnShowDisplayOptionsChanged(
+        DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctrl = (ProfileEditorControl)d;
+        ctrl.displayGroup.Visibility = (bool)e.NewValue ? Visibility.Visible : Visibility.Collapsed;
+    }
+}

--- a/src/LEGUI/ProfileEditorControl.xaml.cs
+++ b/src/LEGUI/ProfileEditorControl.xaml.cs
@@ -9,8 +9,14 @@ namespace LEGUI;
 
 public partial class ProfileEditorControl : UserControl
 {
-    private readonly List<CultureInfo> _cultureInfos;
-    private readonly List<TimeZoneInfo> _timezones;
+    // Static cache: both lists are OS-wide and stable for the process lifetime.
+    // CultureInfo.GetCultures(AllCultures) returns 800+ entries and is noticeably
+    // expensive; rebuilding it per control instance (two windows × reopens) was
+    // wasteful.
+    private static readonly List<CultureInfo> s_cultureInfos =
+        CultureInfo.GetCultures(CultureTypes.AllCultures).OrderBy(i => i.DisplayName).ToList();
+    private static readonly List<TimeZoneInfo> s_timezones =
+        TimeZoneInfo.GetSystemTimeZones().ToList();
 
     public static readonly DependencyProperty ShowDisplayOptionsProperty =
         DependencyProperty.Register(
@@ -28,19 +34,14 @@ public partial class ProfileEditorControl : UserControl
     public ProfileEditorControl()
     {
         InitializeComponent();
-
-        _cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures)
-            .OrderBy(i => i.DisplayName).ToList();
-        cbLocation.ItemsSource = _cultureInfos.Select(c => c.DisplayName);
-
-        _timezones = TimeZoneInfo.GetSystemTimeZones().ToList();
-        cbTimezone.ItemsSource = _timezones.Select(t => t.DisplayName);
+        cbLocation.ItemsSource = s_cultureInfos.Select(c => c.DisplayName);
+        cbTimezone.ItemsSource = s_timezones.Select(t => t.DisplayName);
     }
 
     public void LoadProfile(LEProfile source)
     {
-        cbLocation.SelectedIndex = _cultureInfos.FindIndex(ci => ci.Name == source.Location);
-        cbTimezone.SelectedIndex = _timezones.FindIndex(tz => tz.Id == source.Timezone);
+        cbLocation.SelectedIndex = s_cultureInfos.FindIndex(ci => ci.Name == source.Location);
+        cbTimezone.SelectedIndex = s_timezones.FindIndex(tz => tz.Id == source.Timezone);
         cbStartAsAdmin.IsChecked = source.RunAsAdmin;
         cbRedirectRegistry.IsChecked = source.RedirectRegistry;
         cbIsAdvancedRedirection.IsChecked = source.IsAdvancedRedirection;
@@ -57,8 +58,8 @@ public partial class ProfileEditorControl : UserControl
             template.Guid,
             ShowDisplayOptions ? cbShowInMainMenu.IsChecked == true : template.ShowInMainMenu,
             template.Parameter,
-            locationIdx >= 0 ? _cultureInfos[locationIdx].Name : template.Location,
-            timezoneIdx >= 0 ? _timezones[timezoneIdx].Id : template.Timezone,
+            locationIdx >= 0 ? s_cultureInfos[locationIdx].Name : template.Location,
+            timezoneIdx >= 0 ? s_timezones[timezoneIdx].Id : template.Timezone,
             cbStartAsAdmin.IsChecked == true,
             cbRedirectRegistry.IsChecked == true,
             cbIsAdvancedRedirection.IsChecked == true,

--- a/src/LEGUI/ShellExtCliCommand.cs
+++ b/src/LEGUI/ShellExtCliCommand.cs
@@ -1,0 +1,66 @@
+#nullable enable
+
+namespace LEGUI;
+
+/// <summary>
+/// Parser for --shell-ext command-line arguments.
+///
+/// Usage:
+///   LEGUI.exe --shell-ext install current-user
+///   LEGUI.exe --shell-ext install all-users
+///   LEGUI.exe --shell-ext uninstall current-user
+///   LEGUI.exe --shell-ext uninstall all-users
+///   LEGUI.exe --shell-ext cleanup-old
+/// </summary>
+public sealed class ShellExtCliCommand
+{
+    /// <summary>
+    /// Verb (action) for Shell Extension command.
+    /// </summary>
+    public enum Verb { Install, Uninstall, CleanupOld }
+
+    /// <summary>
+    /// Parsed verb.
+    /// </summary>
+    public Verb ActionVerb { get; }
+
+    /// <summary>
+    /// Parsed install mode. For CleanupOld, defaults to AllUsers (cleanup both HKCU and HKLM).
+    /// </summary>
+    public ShellExtensionRegistrar.InstallMode Mode { get; }
+
+    private ShellExtCliCommand(Verb verb, ShellExtensionRegistrar.InstallMode mode)
+    {
+        ActionVerb = verb;
+        Mode = mode;
+    }
+
+    /// <summary>
+    /// Parse command-line arguments for --shell-ext command.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Parsed command, or null if args do not match --shell-ext pattern.</returns>
+    public static ShellExtCliCommand? Parse(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "--shell-ext") return null;
+
+        return args[1] switch
+        {
+            "install" when args.Length == 3 && TryParseMode(args[2], out var im)
+                => new ShellExtCliCommand(Verb.Install, im),
+            "uninstall" when args.Length == 3 && TryParseMode(args[2], out var um)
+                => new ShellExtCliCommand(Verb.Uninstall, um),
+            "cleanup-old" when args.Length == 2
+                => new ShellExtCliCommand(Verb.CleanupOld, ShellExtensionRegistrar.InstallMode.AllUsers),
+            _ => null
+        };
+    }
+
+    private static bool TryParseMode(string s, out ShellExtensionRegistrar.InstallMode mode)
+    {
+        mode = default;
+        if (s == "current-user") { mode = ShellExtensionRegistrar.InstallMode.CurrentUser; return true; }
+        if (s == "all-users")    { mode = ShellExtensionRegistrar.InstallMode.AllUsers; return true; }
+        return false;
+    }
+}

--- a/src/LEGUI/ShellExtCliCommand.cs
+++ b/src/LEGUI/ShellExtCliCommand.cs
@@ -14,6 +14,13 @@ namespace LEGUI;
 /// </summary>
 public sealed class ShellExtCliCommand
 {
+    public const string Prefix = "--shell-ext";
+    public const string VerbInstall = "install";
+    public const string VerbUninstall = "uninstall";
+    public const string VerbCleanupOld = "cleanup-old";
+    public const string ScopeCurrentUser = "current-user";
+    public const string ScopeAllUsers = "all-users";
+
     /// <summary>
     /// Verb (action) for Shell Extension command.
     /// </summary>
@@ -42,15 +49,15 @@ public sealed class ShellExtCliCommand
     /// <returns>Parsed command, or null if args do not match --shell-ext pattern.</returns>
     public static ShellExtCliCommand? Parse(string[] args)
     {
-        if (args.Length < 2 || args[0] != "--shell-ext") return null;
+        if (args.Length < 2 || args[0] != Prefix) return null;
 
         return args[1] switch
         {
-            "install" when args.Length == 3 && TryParseMode(args[2], out var im)
+            VerbInstall when args.Length == 3 && TryParseMode(args[2], out var im)
                 => new ShellExtCliCommand(Verb.Install, im),
-            "uninstall" when args.Length == 3 && TryParseMode(args[2], out var um)
+            VerbUninstall when args.Length == 3 && TryParseMode(args[2], out var um)
                 => new ShellExtCliCommand(Verb.Uninstall, um),
-            "cleanup-old" when args.Length == 2
+            VerbCleanupOld when args.Length == 2
                 => new ShellExtCliCommand(Verb.CleanupOld, ShellExtensionRegistrar.InstallMode.AllUsers),
             _ => null
         };
@@ -59,8 +66,8 @@ public sealed class ShellExtCliCommand
     private static bool TryParseMode(string s, out ShellExtensionRegistrar.InstallMode mode)
     {
         mode = default;
-        if (s == "current-user") { mode = ShellExtensionRegistrar.InstallMode.CurrentUser; return true; }
-        if (s == "all-users")    { mode = ShellExtensionRegistrar.InstallMode.AllUsers; return true; }
+        if (s == ScopeCurrentUser) { mode = ShellExtensionRegistrar.InstallMode.CurrentUser; return true; }
+        if (s == ScopeAllUsers)    { mode = ShellExtensionRegistrar.InstallMode.AllUsers; return true; }
         return false;
     }
 }

--- a/src/LEGUI/ShellExtensionPanel.xaml
+++ b/src/LEGUI/ShellExtensionPanel.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="LEGUI.ShellExtensionPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="8" TextElement.FontFamily="{DynamicResource UIFont}">
+        <GroupBox Header="Current User" Margin="0,4">
+            <StackPanel Margin="8">
+                <TextBlock>
+                    <Run Text="{DynamicResource InstallStatus}" />
+                    <Run x:Name="tStatusCurrentUser" FontWeight="Bold" />
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button x:Name="bInstallCurrentUser" Content="{DynamicResource InstallCurrentUser}"
+                            MinWidth="120" Margin="0,0,8,0" />
+                    <Button x:Name="bUninstallCurrentUser" Content="{DynamicResource Uninstall}"
+                            MinWidth="100" />
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+        <GroupBox Header="All Users &#x1F6E1;" Margin="0,4">
+            <StackPanel Margin="8">
+                <TextBlock>
+                    <Run Text="{DynamicResource InstallStatus}" />
+                    <Run x:Name="tStatusAllUsers" FontWeight="Bold" />
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button x:Name="bInstallAllUsers" Content="{DynamicResource InstallAllUsers}"
+                            MinWidth="120" Margin="0,0,8,0" />
+                    <Button x:Name="bUninstallAllUsers" Content="{DynamicResource Uninstall}"
+                            MinWidth="100" />
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+        <StackPanel x:Name="cleanupSection" Visibility="Collapsed" Margin="0,8">
+            <TextBlock Text="&#x26A0; Old version residue detected" Foreground="DarkRed" />
+            <Button x:Name="bCleanupOld" Content="Clean up old registration" MinWidth="180"
+                    HorizontalAlignment="Left" Margin="0,4,0,0" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/LEGUI/ShellExtensionPanel.xaml
+++ b/src/LEGUI/ShellExtensionPanel.xaml
@@ -10,9 +10,9 @@
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                     <Button x:Name="bInstallCurrentUser" Content="{DynamicResource InstallCurrentUser}"
-                            MinWidth="120" Margin="0,0,8,0" />
+                            MinWidth="120" Margin="0,0,8,0" Click="bInstallCurrentUser_Click" />
                     <Button x:Name="bUninstallCurrentUser" Content="{DynamicResource Uninstall}"
-                            MinWidth="100" />
+                            MinWidth="100" Click="bUninstallCurrentUser_Click" />
                 </StackPanel>
             </StackPanel>
         </GroupBox>
@@ -24,16 +24,16 @@
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                     <Button x:Name="bInstallAllUsers" Content="{DynamicResource InstallAllUsers}"
-                            MinWidth="120" Margin="0,0,8,0" />
+                            MinWidth="120" Margin="0,0,8,0" Click="bInstallAllUsers_Click" />
                     <Button x:Name="bUninstallAllUsers" Content="{DynamicResource Uninstall}"
-                            MinWidth="100" />
+                            MinWidth="100" Click="bUninstallAllUsers_Click" />
                 </StackPanel>
             </StackPanel>
         </GroupBox>
         <StackPanel x:Name="cleanupSection" Visibility="Collapsed" Margin="0,8">
             <TextBlock Text="{DynamicResource ShellExtOldResidueDetected}" Foreground="DarkRed" />
             <Button x:Name="bCleanupOld" Content="{DynamicResource ShellExtCleanupOld}" MinWidth="180"
-                    HorizontalAlignment="Left" Margin="0,4,0,0" />
+                    HorizontalAlignment="Left" Margin="0,4,0,0" Click="bCleanupOld_Click" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/LEGUI/ShellExtensionPanel.xaml
+++ b/src/LEGUI/ShellExtensionPanel.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StackPanel Margin="8" TextElement.FontFamily="{DynamicResource UIFont}">
-        <GroupBox Header="Current User" Margin="0,4">
+        <GroupBox Header="{DynamicResource ShellExtCurrentUserHeader}" Margin="0,4">
             <StackPanel Margin="8">
                 <TextBlock>
                     <Run Text="{DynamicResource InstallStatus}" />
@@ -16,7 +16,7 @@
                 </StackPanel>
             </StackPanel>
         </GroupBox>
-        <GroupBox Header="All Users &#x1F6E1;" Margin="0,4">
+        <GroupBox Header="{DynamicResource ShellExtAllUsersHeader}" Margin="0,4">
             <StackPanel Margin="8">
                 <TextBlock>
                     <Run Text="{DynamicResource InstallStatus}" />
@@ -31,8 +31,8 @@
             </StackPanel>
         </GroupBox>
         <StackPanel x:Name="cleanupSection" Visibility="Collapsed" Margin="0,8">
-            <TextBlock Text="&#x26A0; Old version residue detected" Foreground="DarkRed" />
-            <Button x:Name="bCleanupOld" Content="Clean up old registration" MinWidth="180"
+            <TextBlock Text="{DynamicResource ShellExtOldResidueDetected}" Foreground="DarkRed" />
+            <Button x:Name="bCleanupOld" Content="{DynamicResource ShellExtCleanupOld}" MinWidth="180"
                     HorizontalAlignment="Left" Margin="0,4,0,0" />
         </StackPanel>
     </StackPanel>

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -9,7 +9,6 @@ namespace LEGUI;
 
 public partial class ShellExtensionPanel : UserControl
 {
-    private IShellExtensionQuery _query;
     private IShellExtensionCommand _command;
     private string _dllPath;
     private bool _isAdmin;
@@ -26,8 +25,6 @@ public partial class ShellExtensionPanel : UserControl
         InitializeComponent();
     }
 
-    public void SetQuery(IShellExtensionQuery query) => _query = query;
-
     /// <summary>Wire up install/uninstall actions. AllUsers mode when !isAdmin is routed
     /// through a UAC-elevated sub-process via RunElevatedAsync.</summary>
     public void SetCommand(IShellExtensionCommand command, string dllPath, bool isAdmin)
@@ -35,15 +32,14 @@ public partial class ShellExtensionPanel : UserControl
         _command = command;
         _dllPath = dllPath;
         _isAdmin = isAdmin;
-        SetQuery(command);
     }
 
     public void RefreshStatus()
     {
-        if (_query == null) return;
+        if (_command == null) return;
 
-        var cuInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser);
-        var auInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers);
+        var cuInstalled = _command.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser);
+        var auInstalled = _command.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers);
 
         tStatusCurrentUser.Text = " " + I18n.GetString(cuInstalled ? "Installed" : "NotInstalled");
         tStatusAllUsers.Text = " " + I18n.GetString(auInstalled ? "Installed" : "NotInstalled");
@@ -53,7 +49,7 @@ public partial class ShellExtensionPanel : UserControl
         bInstallAllUsers.IsEnabled = !auInstalled;
         bUninstallAllUsers.IsEnabled = auInstalled;
 
-        cleanupSection.Visibility = _query.HasOldRegistration()
+        cleanupSection.Visibility = _command.HasOldRegistration()
             ? Visibility.Visible
             : Visibility.Collapsed;
     }
@@ -78,7 +74,7 @@ public partial class ShellExtensionPanel : UserControl
         }
         else
         {
-            await RunElevatedAsync("cleanup-old", null);
+            await RunElevatedAsync(ShellExtCliCommand.VerbCleanupOld, null);
         }
         RefreshStatus();
     }
@@ -87,7 +83,7 @@ public partial class ShellExtensionPanel : UserControl
     {
         if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
         {
-            if (!await RunElevatedAsync("install", "all-users"))
+            if (!await RunElevatedAsync(ShellExtCliCommand.VerbInstall, ShellExtCliCommand.ScopeAllUsers))
             {
                 RefreshStatus();
                 return;
@@ -110,7 +106,7 @@ public partial class ShellExtensionPanel : UserControl
     {
         if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
         {
-            if (!await RunElevatedAsync("uninstall", "all-users"))
+            if (!await RunElevatedAsync(ShellExtCliCommand.VerbUninstall, ShellExtCliCommand.ScopeAllUsers))
             {
                 RefreshStatus();
                 return;
@@ -153,7 +149,9 @@ public partial class ShellExtensionPanel : UserControl
         SetAllButtonsEnabled(false);
         try
         {
-            var args = scope != null ? $"--shell-ext {verb} {scope}" : $"--shell-ext {verb}";
+            var args = scope != null
+                ? $"{ShellExtCliCommand.Prefix} {verb} {scope}"
+                : $"{ShellExtCliCommand.Prefix} {verb}";
             var psi = new ProcessStartInfo
             {
                 FileName = Environment.ProcessPath,

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -23,8 +23,8 @@ public partial class ShellExtensionPanel : UserControl
         var cuInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser);
         var auInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers);
 
-        tStatusCurrentUser.Text = " " + GetStatusText(cuInstalled);
-        tStatusAllUsers.Text = " " + GetStatusText(auInstalled);
+        tStatusCurrentUser.Text = " " + I18n.GetString(cuInstalled ? "Installed" : "NotInstalled");
+        tStatusAllUsers.Text = " " + I18n.GetString(auInstalled ? "Installed" : "NotInstalled");
 
         bInstallCurrentUser.IsEnabled = !cuInstalled;
         bUninstallCurrentUser.IsEnabled = cuInstalled;
@@ -34,17 +34,5 @@ public partial class ShellExtensionPanel : UserControl
         cleanupSection.Visibility = _query.HasOldRegistration()
             ? Visibility.Visible
             : Visibility.Collapsed;
-    }
-
-    private static string GetStatusText(bool installed)
-    {
-        try
-        {
-            return I18n.GetString(installed ? "Installed" : "NotInstalled");
-        }
-        catch
-        {
-            return installed ? "Installed" : "Not Installed";
-        }
     }
 }

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -74,7 +74,7 @@ public partial class ShellExtensionPanel : UserControl
     {
         if (_isAdmin)
         {
-            _command?.CleanupOldRegistration();
+            TryInProcess(() => _command?.CleanupOldRegistration());
         }
         else
         {
@@ -95,7 +95,11 @@ public partial class ShellExtensionPanel : UserControl
         }
         else
         {
-            _command?.Register(mode, _dllPath);
+            if (!TryInProcess(() => _command?.Register(mode, _dllPath)))
+            {
+                RefreshStatus();
+                return;
+            }
         }
         RefreshStatus();
         if (_command != null)
@@ -114,11 +118,30 @@ public partial class ShellExtensionPanel : UserControl
         }
         else
         {
-            _command?.Unregister(mode);
+            if (!TryInProcess(() => _command?.Unregister(mode)))
+            {
+                RefreshStatus();
+                return;
+            }
         }
         RefreshStatus();
         if (_command != null)
             ShowMessage(I18n.GetString("UninstallSuccess"));
+    }
+
+    /// <summary>Run an in-process registry operation, showing a localized error and returning false on failure.</summary>
+    private bool TryInProcess(Action op)
+    {
+        try
+        {
+            op();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            ShowMessage(string.Format(I18n.GetString("ShellExtOperationFailed"), ex.Message));
+            return false;
+        }
     }
 
     /// <summary>
@@ -146,7 +169,7 @@ public partial class ShellExtensionPanel : UserControl
 
             if (p.ExitCode != 0)
             {
-                ShowMessage($"Operation failed with exit code {p.ExitCode}.");
+                ShowMessage(string.Format(I18n.GetString("ShellExtOperationFailed"), $"exit code {p.ExitCode}"));
                 return false;
             }
             return true;

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -1,0 +1,50 @@
+#nullable disable
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LEGUI;
+
+public partial class ShellExtensionPanel : UserControl
+{
+    private IShellExtensionQuery _query;
+
+    public ShellExtensionPanel()
+    {
+        InitializeComponent();
+    }
+
+    public void SetQuery(IShellExtensionQuery query) => _query = query;
+
+    public void RefreshStatus()
+    {
+        if (_query == null) return;
+
+        var cuInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser);
+        var auInstalled = _query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+        tStatusCurrentUser.Text = " " + GetStatusText(cuInstalled);
+        tStatusAllUsers.Text = " " + GetStatusText(auInstalled);
+
+        bInstallCurrentUser.IsEnabled = !cuInstalled;
+        bUninstallCurrentUser.IsEnabled = cuInstalled;
+        bInstallAllUsers.IsEnabled = !auInstalled;
+        bUninstallAllUsers.IsEnabled = auInstalled;
+
+        cleanupSection.Visibility = _query.HasOldRegistration()
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private static string GetStatusText(bool installed)
+    {
+        try
+        {
+            return I18n.GetString(installed ? "Installed" : "NotInstalled");
+        }
+        catch
+        {
+            return installed ? "Installed" : "Not Installed";
+        }
+    }
+}

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -10,6 +10,8 @@ public partial class ShellExtensionPanel : UserControl
     private IShellExtensionQuery _query;
     private IShellExtensionCommand _command;
     private string _dllPath;
+    // Reserved for Task 5.3: when false, AllUsers actions will be routed through
+    // a UAC-elevated sub-process. Until then, this field is stored but not read.
     private bool _isAdmin;
 
     /// <summary>

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -1,5 +1,7 @@
 #nullable disable
 
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -10,8 +12,6 @@ public partial class ShellExtensionPanel : UserControl
     private IShellExtensionQuery _query;
     private IShellExtensionCommand _command;
     private string _dllPath;
-    // Reserved for Task 5.3: when false, AllUsers actions will be routed through
-    // a UAC-elevated sub-process. Until then, this field is stored but not read.
     private bool _isAdmin;
 
     /// <summary>
@@ -28,8 +28,8 @@ public partial class ShellExtensionPanel : UserControl
 
     public void SetQuery(IShellExtensionQuery query) => _query = query;
 
-    /// <summary>Wire up install/uninstall actions. Task 4.2 is in-process admin path only;
-    /// Task 5.3 will add UAC-elevated sub-process for AllUsers mode when !isAdmin.</summary>
+    /// <summary>Wire up install/uninstall actions. AllUsers mode when !isAdmin is routed
+    /// through a UAC-elevated sub-process via RunElevatedAsync.</summary>
     public void SetCommand(IShellExtensionCommand command, string dllPath, bool isAdmin)
     {
         _command = command;
@@ -58,40 +58,116 @@ public partial class ShellExtensionPanel : UserControl
             : Visibility.Collapsed;
     }
 
-    private void bInstallCurrentUser_Click(object sender, RoutedEventArgs e)
-        => HandleInstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+    private async void bInstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => await HandleInstallAsync(ShellExtensionRegistrar.InstallMode.CurrentUser);
 
-    private void bInstallAllUsers_Click(object sender, RoutedEventArgs e)
-        => HandleInstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+    private async void bInstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => await HandleInstallAsync(ShellExtensionRegistrar.InstallMode.AllUsers);
 
-    private void bUninstallCurrentUser_Click(object sender, RoutedEventArgs e)
-        => HandleUninstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+    private async void bUninstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => await HandleUninstallAsync(ShellExtensionRegistrar.InstallMode.CurrentUser);
 
-    private void bUninstallAllUsers_Click(object sender, RoutedEventArgs e)
-        => HandleUninstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+    private async void bUninstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => await HandleUninstallAsync(ShellExtensionRegistrar.InstallMode.AllUsers);
 
-    private void bCleanupOld_Click(object sender, RoutedEventArgs e)
+    private async void bCleanupOld_Click(object sender, RoutedEventArgs e)
     {
-        // NOTE: AllUsers cleanup writes HKLM which requires admin. Task 5.3 will route
-        // non-admin requests through a UAC-elevated sub-process.
-        _command?.CleanupOldRegistration();
+        if (_isAdmin)
+        {
+            _command?.CleanupOldRegistration();
+        }
+        else
+        {
+            await RunElevatedAsync("cleanup-old", null);
+        }
         RefreshStatus();
     }
 
-    private void HandleInstall(ShellExtensionRegistrar.InstallMode mode)
+    private async Task HandleInstallAsync(ShellExtensionRegistrar.InstallMode mode)
     {
-        // NOTE: Task 5.3 will route non-admin AllUsers requests through sub-process with UAC.
-        _command?.Register(mode, _dllPath);
+        if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
+        {
+            if (!await RunElevatedAsync("install", "all-users"))
+            {
+                RefreshStatus();
+                return;
+            }
+        }
+        else
+        {
+            _command?.Register(mode, _dllPath);
+        }
         RefreshStatus();
         if (_command != null)
             ShowMessage(I18n.GetString("InstallSuccess"));
     }
 
-    private void HandleUninstall(ShellExtensionRegistrar.InstallMode mode)
+    private async Task HandleUninstallAsync(ShellExtensionRegistrar.InstallMode mode)
     {
-        _command?.Unregister(mode);
+        if (mode == ShellExtensionRegistrar.InstallMode.AllUsers && !_isAdmin)
+        {
+            if (!await RunElevatedAsync("uninstall", "all-users"))
+            {
+                RefreshStatus();
+                return;
+            }
+        }
+        else
+        {
+            _command?.Unregister(mode);
+        }
         RefreshStatus();
         if (_command != null)
             ShowMessage(I18n.GetString("UninstallSuccess"));
+    }
+
+    /// <summary>
+    /// Spawn LEGUI.exe with --shell-ext CLI and "runas" verb to trigger UAC.
+    /// Returns true on success (exit code 0), false on cancellation or failure.
+    /// </summary>
+    private async Task<bool> RunElevatedAsync(string verb, string scope)
+    {
+        SetAllButtonsEnabled(false);
+        try
+        {
+            var args = scope != null ? $"--shell-ext {verb} {scope}" : $"--shell-ext {verb}";
+            var psi = new ProcessStartInfo
+            {
+                FileName = Environment.ProcessPath,
+                Arguments = args,
+                Verb = "runas",
+                UseShellExecute = true
+            };
+
+            using var p = Process.Start(psi);
+            if (p == null) return false;
+
+            await p.WaitForExitAsync();
+
+            if (p.ExitCode != 0)
+            {
+                ShowMessage($"Operation failed with exit code {p.ExitCode}.");
+                return false;
+            }
+            return true;
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == 1223)
+        {
+            // User cancelled UAC prompt — silently return, do not show error.
+            return false;
+        }
+        finally
+        {
+            SetAllButtonsEnabled(true);
+        }
+    }
+
+    private void SetAllButtonsEnabled(bool enabled)
+    {
+        bInstallCurrentUser.IsEnabled = enabled;
+        bUninstallCurrentUser.IsEnabled = enabled;
+        bInstallAllUsers.IsEnabled = enabled;
+        bUninstallAllUsers.IsEnabled = enabled;
+        bCleanupOld.IsEnabled = enabled;
     }
 }

--- a/src/LEGUI/ShellExtensionPanel.xaml.cs
+++ b/src/LEGUI/ShellExtensionPanel.xaml.cs
@@ -8,6 +8,16 @@ namespace LEGUI;
 public partial class ShellExtensionPanel : UserControl
 {
     private IShellExtensionQuery _query;
+    private IShellExtensionCommand _command;
+    private string _dllPath;
+    private bool _isAdmin;
+
+    /// <summary>
+    /// Replaceable message shower — defaults to MessageBox.Show.
+    /// Tests can swap this out to avoid blocking on a modal dialog.
+    /// </summary>
+    internal Action<string> ShowMessage = text =>
+        MessageBox.Show(text, "Locale Emulator");
 
     public ShellExtensionPanel()
     {
@@ -15,6 +25,16 @@ public partial class ShellExtensionPanel : UserControl
     }
 
     public void SetQuery(IShellExtensionQuery query) => _query = query;
+
+    /// <summary>Wire up install/uninstall actions. Task 4.2 is in-process admin path only;
+    /// Task 5.3 will add UAC-elevated sub-process for AllUsers mode when !isAdmin.</summary>
+    public void SetCommand(IShellExtensionCommand command, string dllPath, bool isAdmin)
+    {
+        _command = command;
+        _dllPath = dllPath;
+        _isAdmin = isAdmin;
+        SetQuery(command);
+    }
 
     public void RefreshStatus()
     {
@@ -34,5 +54,42 @@ public partial class ShellExtensionPanel : UserControl
         cleanupSection.Visibility = _query.HasOldRegistration()
             ? Visibility.Visible
             : Visibility.Collapsed;
+    }
+
+    private void bInstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => HandleInstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+
+    private void bInstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => HandleInstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+    private void bUninstallCurrentUser_Click(object sender, RoutedEventArgs e)
+        => HandleUninstall(ShellExtensionRegistrar.InstallMode.CurrentUser);
+
+    private void bUninstallAllUsers_Click(object sender, RoutedEventArgs e)
+        => HandleUninstall(ShellExtensionRegistrar.InstallMode.AllUsers);
+
+    private void bCleanupOld_Click(object sender, RoutedEventArgs e)
+    {
+        // NOTE: AllUsers cleanup writes HKLM which requires admin. Task 5.3 will route
+        // non-admin requests through a UAC-elevated sub-process.
+        _command?.CleanupOldRegistration();
+        RefreshStatus();
+    }
+
+    private void HandleInstall(ShellExtensionRegistrar.InstallMode mode)
+    {
+        // NOTE: Task 5.3 will route non-admin AllUsers requests through sub-process with UAC.
+        _command?.Register(mode, _dllPath);
+        RefreshStatus();
+        if (_command != null)
+            ShowMessage(I18n.GetString("InstallSuccess"));
+    }
+
+    private void HandleUninstall(ShellExtensionRegistrar.InstallMode mode)
+    {
+        _command?.Unregister(mode);
+        RefreshStatus();
+        if (_command != null)
+            ShowMessage(I18n.GetString("UninstallSuccess"));
     }
 }

--- a/src/LEGUI/ShellExtensionRegistrar.cs
+++ b/src/LEGUI/ShellExtensionRegistrar.cs
@@ -159,6 +159,25 @@ public sealed class ShellExtensionRegistrar : IShellExtensionCommand
     }
 
     /// <summary>
+    /// Resolve the Shell Extension build output root (the parent directory of the
+    /// x86/x64 sub-folders). Uses the current process's parent-of-parent directory
+    /// (e.g. Build/Release/x86/LEGUI.exe → Build/Release/), falling back to
+    /// AppContext.BaseDirectory when ProcessPath is unavailable or shallower than
+    /// two levels deep.
+    /// </summary>
+    public static string GetBuildOutputRoot()
+    {
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrEmpty(processPath))
+        {
+            var parent = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
+            if (!string.IsNullOrEmpty(parent))
+                return parent;
+        }
+        return AppContext.BaseDirectory;
+    }
+
+    /// <summary>
     /// Auto-detect DLL path based on OS bitness.
     /// </summary>
     /// <param name="basePath">Build output root directory.</param>

--- a/src/LEGUI/ShellExtensionRegistrar.cs
+++ b/src/LEGUI/ShellExtensionRegistrar.cs
@@ -14,7 +14,7 @@ namespace LEGUI;
 /// - No DllRegisterServer, no LoadLibrary, no regsvr32
 /// - Responsible for detecting and cleaning old COM GUID residues
 /// </summary>
-public sealed class ShellExtensionRegistrar
+public sealed class ShellExtensionRegistrar : IShellExtensionQuery
 {
     /// <summary>
     /// Old LEContextMenuHandler COM GUID (needs cleanup).
@@ -132,6 +132,12 @@ public sealed class ShellExtensionRegistrar
             _registry.DeleteSubKeyTree(hive, subKey, view, throwOnMissing: false);
         }
     }
+
+    // Explicit interface implementation: delegates to the overload with optional is64BitOs.
+    bool IShellExtensionQuery.IsInstalled(InstallMode mode) => IsInstalled(mode, null);
+
+    // Explicit interface implementation: delegates to the overload with optional is64BitOs.
+    bool IShellExtensionQuery.HasOldRegistration() => HasOldRegistration(null);
 
     /// <summary>
     /// Check if the Shell Extension is installed.

--- a/src/LEGUI/ShellExtensionRegistrar.cs
+++ b/src/LEGUI/ShellExtensionRegistrar.cs
@@ -14,7 +14,7 @@ namespace LEGUI;
 /// - No DllRegisterServer, no LoadLibrary, no regsvr32
 /// - Responsible for detecting and cleaning old COM GUID residues
 /// </summary>
-public sealed class ShellExtensionRegistrar : IShellExtensionQuery
+public sealed class ShellExtensionRegistrar : IShellExtensionCommand
 {
     /// <summary>
     /// Old LEContextMenuHandler COM GUID (needs cleanup).
@@ -138,6 +138,11 @@ public sealed class ShellExtensionRegistrar : IShellExtensionQuery
 
     // Explicit interface implementation: delegates to the overload with optional is64BitOs.
     bool IShellExtensionQuery.HasOldRegistration() => HasOldRegistration(null);
+
+    // Explicit IShellExtensionCommand implementations: delegate to the public overloads.
+    void IShellExtensionCommand.Register(InstallMode mode, string dllPath) => Register(mode, dllPath);
+    void IShellExtensionCommand.Unregister(InstallMode mode) => Unregister(mode);
+    void IShellExtensionCommand.CleanupOldRegistration() => CleanupOldRegistration();
 
     /// <summary>
     /// Check if the Shell Extension is installed.

--- a/tests/LEGUI.Tests/LEGUI.Tests.csproj
+++ b/tests/LEGUI.Tests/LEGUI.Tests.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="Xunit.StaFact" Version="1.*" />
     <PackageReference Include="coverlet.collector" Version="6.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/LEGUI.Tests/ProfileEditorControlTests.cs
+++ b/tests/LEGUI.Tests/ProfileEditorControlTests.cs
@@ -1,0 +1,35 @@
+using LECommonLibrary;
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ProfileEditorControlTests
+{
+    private static LEProfile SampleProfile() => new LEProfile(
+        "TestProfile", "{00000000-0000-0000-0000-000000000001}",
+        showInMainMenu: true, parameter: "",
+        location: "ja-JP", timezone: "Tokyo Standard Time",
+        runAsAdmin: false, redirectRegistry: true,
+        isAdvancedRedirection: false, runWithSuspend: false);
+
+    [WpfFact]
+    public void LoadThenRead_RoundTripsAllFields()
+    {
+        var ctrl = new ProfileEditorControl();
+        var original = SampleProfile();
+
+        ctrl.LoadProfile(original);
+        var result = ctrl.ReadProfile(original);
+
+        Assert.Equal(original.Location, result.Location);
+        Assert.Equal(original.Timezone, result.Timezone);
+        Assert.Equal(original.RunAsAdmin, result.RunAsAdmin);
+        Assert.Equal(original.RedirectRegistry, result.RedirectRegistry);
+        Assert.Equal(original.IsAdvancedRedirection, result.IsAdvancedRedirection);
+        Assert.Equal(original.RunWithSuspend, result.RunWithSuspend);
+        Assert.Equal(original.ShowInMainMenu, result.ShowInMainMenu);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.Guid, result.Guid);
+        Assert.Equal(original.Parameter, result.Parameter);
+    }
+}

--- a/tests/LEGUI.Tests/ProfileEditorControlTests.cs
+++ b/tests/LEGUI.Tests/ProfileEditorControlTests.cs
@@ -34,4 +34,28 @@ public class ProfileEditorControlTests
         Assert.Equal(original.Guid, result.Guid);
         Assert.Equal(original.Parameter, result.Parameter);
     }
+
+    [WpfFact]
+    public void ShowDisplayOptionsFalse_HidesDisplayGroup()
+    {
+        var ctrl = new ProfileEditorControl();
+        ctrl.ShowDisplayOptions = false;
+
+        Assert.Equal(System.Windows.Visibility.Collapsed, ctrl.displayGroup.Visibility);
+    }
+
+    [WpfFact]
+    public void ShowDisplayOptionsFalse_ReadProfilePreservesShowInMainMenuFromTemplate()
+    {
+        var ctrl = new ProfileEditorControl();
+        ctrl.ShowDisplayOptions = false;
+        var template = SampleProfile(); // ShowInMainMenu=true
+        ctrl.LoadProfile(template);
+
+        // Even if user changes cbShowInMainMenu via UI, ReadProfile should preserve template value.
+        ctrl.cbShowInMainMenu.IsChecked = false;
+        var result = ctrl.ReadProfile(template);
+
+        Assert.True(result.ShowInMainMenu); // preserved from template
+    }
 }

--- a/tests/LEGUI.Tests/ProfileEditorControlTests.cs
+++ b/tests/LEGUI.Tests/ProfileEditorControlTests.cs
@@ -5,12 +5,14 @@ namespace LEGUI.Tests;
 
 public class ProfileEditorControlTests
 {
+    // All booleans deliberately set to values that differ from an un-toggled CheckBox default (false),
+    // so a hypothetical no-op LoadProfile would fail this round-trip test instead of false-passing.
     private static LEProfile SampleProfile() => new LEProfile(
         "TestProfile", "{00000000-0000-0000-0000-000000000001}",
-        showInMainMenu: true, parameter: "",
+        showInMainMenu: true, parameter: "arg1",
         location: "ja-JP", timezone: "Tokyo Standard Time",
-        runAsAdmin: false, redirectRegistry: true,
-        isAdvancedRedirection: false, runWithSuspend: false);
+        runAsAdmin: true, redirectRegistry: true,
+        isAdvancedRedirection: true, runWithSuspend: true);
 
     [WpfFact]
     public void LoadThenRead_RoundTripsAllFields()

--- a/tests/LEGUI.Tests/ShellExtCliCommandTests.cs
+++ b/tests/LEGUI.Tests/ShellExtCliCommandTests.cs
@@ -1,0 +1,46 @@
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ShellExtCliCommandTests
+{
+    [Theory]
+    [InlineData(new[] { "--shell-ext", "install", "current-user" },
+                ShellExtCliCommand.Verb.Install,
+                ShellExtensionRegistrar.InstallMode.CurrentUser)]
+    [InlineData(new[] { "--shell-ext", "install", "all-users" },
+                ShellExtCliCommand.Verb.Install,
+                ShellExtensionRegistrar.InstallMode.AllUsers)]
+    [InlineData(new[] { "--shell-ext", "uninstall", "current-user" },
+                ShellExtCliCommand.Verb.Uninstall,
+                ShellExtensionRegistrar.InstallMode.CurrentUser)]
+    public void Parse_ValidArgs_ReturnsParsedCommand(
+        string[] args, ShellExtCliCommand.Verb verb, ShellExtensionRegistrar.InstallMode mode)
+    {
+        var cmd = ShellExtCliCommand.Parse(args);
+        Assert.NotNull(cmd);
+        Assert.Equal(verb, cmd.ActionVerb);
+        Assert.Equal(mode, cmd.Mode);
+    }
+
+    [Fact]
+    public void Parse_CleanupOld_NoModeRequired()
+    {
+        var cmd = ShellExtCliCommand.Parse(new[] { "--shell-ext", "cleanup-old" });
+        Assert.NotNull(cmd);
+        Assert.Equal(ShellExtCliCommand.Verb.CleanupOld, cmd.ActionVerb);
+    }
+
+    [Fact]
+    public void Parse_NonShellExtArgs_ReturnsNull()
+    {
+        Assert.Null(ShellExtCliCommand.Parse(new[] { "game.exe" }));
+        Assert.Null(ShellExtCliCommand.Parse(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Parse_InvalidVerb_ReturnsNull()
+    {
+        Assert.Null(ShellExtCliCommand.Parse(new[] { "--shell-ext", "xyz", "current-user" }));
+    }
+}

--- a/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
+++ b/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
@@ -1,0 +1,39 @@
+using NSubstitute;
+using Xunit;
+
+namespace LEGUI.Tests;
+
+public class ShellExtensionPanelTests
+{
+    [WpfFact]
+    public void RefreshStatus_WhenCurrentUserInstalled_DisablesInstallButton()
+    {
+        var panel = new ShellExtensionPanel();
+        var query = Substitute.For<IShellExtensionQuery>();
+        query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser).Returns(true);
+        query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers).Returns(false);
+        query.HasOldRegistration().Returns(false);
+
+        panel.SetQuery(query);
+        panel.RefreshStatus();
+
+        Assert.False(panel.bInstallCurrentUser.IsEnabled);
+        Assert.True(panel.bUninstallCurrentUser.IsEnabled);
+        Assert.True(panel.bInstallAllUsers.IsEnabled);
+        Assert.False(panel.bUninstallAllUsers.IsEnabled);
+    }
+
+    [WpfFact]
+    public void RefreshStatus_HasOldRegistration_ShowsCleanupSection()
+    {
+        var panel = new ShellExtensionPanel();
+        var query = Substitute.For<IShellExtensionQuery>();
+        query.IsInstalled(Arg.Any<ShellExtensionRegistrar.InstallMode>()).Returns(false);
+        query.HasOldRegistration().Returns(true);
+
+        panel.SetQuery(query);
+        panel.RefreshStatus();
+
+        Assert.Equal(System.Windows.Visibility.Visible, panel.cleanupSection.Visibility);
+    }
+}

--- a/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
+++ b/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
@@ -36,4 +36,23 @@ public class ShellExtensionPanelTests
 
         Assert.Equal(System.Windows.Visibility.Visible, panel.cleanupSection.Visibility);
     }
+
+    [WpfFact]
+    public void InstallCurrentUser_CallsRegisterWithCurrentUserMode()
+    {
+        var panel = new ShellExtensionPanel();
+        panel.ShowMessage = _ => { }; // suppress dialog in tests
+        var command = Substitute.For<IShellExtensionCommand>();
+        command.IsInstalled(Arg.Any<ShellExtensionRegistrar.InstallMode>()).Returns(false);
+        command.HasOldRegistration().Returns(false);
+
+        panel.SetCommand(command, dllPath: @"C:\fake\ShellExtension.dll", isAdmin: true);
+
+        panel.bInstallCurrentUser.RaiseEvent(
+            new System.Windows.RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent));
+
+        command.Received().Register(
+            ShellExtensionRegistrar.InstallMode.CurrentUser,
+            @"C:\fake\ShellExtension.dll");
+    }
 }

--- a/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
+++ b/tests/LEGUI.Tests/ShellExtensionPanelTests.cs
@@ -9,12 +9,12 @@ public class ShellExtensionPanelTests
     public void RefreshStatus_WhenCurrentUserInstalled_DisablesInstallButton()
     {
         var panel = new ShellExtensionPanel();
-        var query = Substitute.For<IShellExtensionQuery>();
-        query.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser).Returns(true);
-        query.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers).Returns(false);
-        query.HasOldRegistration().Returns(false);
+        var command = Substitute.For<IShellExtensionCommand>();
+        command.IsInstalled(ShellExtensionRegistrar.InstallMode.CurrentUser).Returns(true);
+        command.IsInstalled(ShellExtensionRegistrar.InstallMode.AllUsers).Returns(false);
+        command.HasOldRegistration().Returns(false);
 
-        panel.SetQuery(query);
+        panel.SetCommand(command, dllPath: string.Empty, isAdmin: true);
         panel.RefreshStatus();
 
         Assert.False(panel.bInstallCurrentUser.IsEnabled);
@@ -27,11 +27,11 @@ public class ShellExtensionPanelTests
     public void RefreshStatus_HasOldRegistration_ShowsCleanupSection()
     {
         var panel = new ShellExtensionPanel();
-        var query = Substitute.For<IShellExtensionQuery>();
-        query.IsInstalled(Arg.Any<ShellExtensionRegistrar.InstallMode>()).Returns(false);
-        query.HasOldRegistration().Returns(true);
+        var command = Substitute.For<IShellExtensionCommand>();
+        command.IsInstalled(Arg.Any<ShellExtensionRegistrar.InstallMode>()).Returns(false);
+        command.HasOldRegistration().Returns(true);
 
-        panel.SetQuery(query);
+        panel.SetCommand(command, dllPath: string.Empty, isAdmin: true);
         panel.RefreshStatus();
 
         Assert.Equal(System.Windows.Visibility.Visible, panel.cleanupSection.Visibility);


### PR DESCRIPTION
## 摘要

為 LEGUI 新增 Shell Extension 安裝/解除安裝 UI，並順勢將兩個主視窗（GlobalConfig / AppConfig）從扁平佈局改為 TabControl 分頁結構。抽出共用 `ProfileEditorControl` 消除 95% 重複版面。原 Issue 19 要求的「安裝 UI」只是表象；本 PR 實際交付的是「可擴充的設定對話框架構」。

## 本次 PR 交付

### 主要功能

- **Shell Extension 安裝 UI**：新增「Shell Extension」分頁，提供 Current User / All Users 雙模式的安裝/解除安裝按鈕，以及舊版 CLSID 清理（條件顯示）。
- **UAC 子 process 提權**：非 admin 使用者點「Install (All Users)」時，LEGUI 啟動自己為子 process 並以 `runas` verb 觸發 UAC，主 UI 狀態保留、不丟失未儲存編輯。
- **`--shell-ext` CLI**：`App.xaml.cs` 新增 CLI 分支，含子 process 提權所需的無 UI 執行路徑。

### 架構重構

- **`ProfileEditorControl` UserControl**：抽出 GlobalConfig / AppConfig 共用的 Location/Timezone/Advanced/Display 編輯區塊。AppConfig 以 `ShowDisplayOptions="False"` 隱藏 Display（單檔設定無 ShowInMainMenu 概念）。
- **TabControl 結構**：GlobalConfig = `Profile / Shell Extension / About`；AppConfig = `Profile / About`（Shell Ext 屬系統級設定，不在單檔編輯範圍）。
- **`AboutPanel`**：新增「關於」分頁，版本號透過 `GlobalHelper.GetVersionString()` 讀取，含原作/Core/Fork 連結與授權。

### 附帶清理

- 修 `CREATE__SUSPENDED` 雙底線錯字（Win32 實際常數為單底線）
- `MessageBox.Show` 空標題修正
- `IsChecked != null && (bool)IsChecked` 現代化為 `IsChecked == true`
- 移除 `SaveAs` 的 `BlurEffect`（`ShowDialog()` modal 已足夠）
- 5 個 Advanced Options CheckBox 加 tooltip
- StatusBar + 「Saved」3 秒淡出提示
- 視窗尺寸改固定 `Width/Height`（`SizeToContent` 與 TabControl 互動不穩）

## 主要設計決策與替代方案

完整討論見 `docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md` Section 10。摘要：

### UI scope
- Scope 1（僅 GlobalConfig）被捨棄：兩視窗版面分歧，維護成本升
- **Scope 2 ✓**（兩視窗改 TabControl + 抽 ProfileEditorControl）
- Scope 3（合併兩視窗）被捨棄：屬大型 refactoring 偏離主軸

### Tab 結構
- A（不對稱）被捨棄：視覺不一致
- **B ✓**：兩視窗都用 TabControl，Shell Ext 僅 GlobalConfig（系統級設定），About 兩邊共用
- C（完全對稱）被捨棄：AppConfig 有 Shell Ext 會造成語意錯位

### Shell Ext 分頁佈局
- A（扁平 4 按鈕）被捨棄：狀態與動作未就近擺放
- **B ✓**：Current User / All Users 兩個 GroupBox，各含 Status + Install + Uninstall
- C（單一動作 + radio）被捨棄：掩蓋「兩模式可並存」事實

### UAC 升權
- A（重啟整個 LEGUI）被捨棄：失去未儲存編輯
- **B ✓**：子 process 提權，主 UI 保留
- C（不處理）被捨棄：違反 Windows 慣例

### Profile 重構
- **A ✓**（最小修改）：保留 4 個 GroupBox，同步變數名、補 tooltip、修錯字
- B/C 被捨棄：分別是併 Display 進 Advanced（語意糊）與語意重組（改動面大）

## 測試

- **26 單元測試通過**（起始 14，新增 12）
  - `ProfileEditorControlTests` × 3：Load/Read 往返、ShowDisplayOptions 隱藏、template 保留
  - `ShellExtensionPanelTests` × 3：狀態→按鈕啟用、舊版清理條件顯示、Install 呼叫 Register
  - `ShellExtCliCommandTests` × 6：3 合法 + cleanup-old + 2 negative
- **新套件**：`Xunit.StaFact`（WPF UserControl 需 STA thread）
- **Smoke test（CLI）**：install/uninstall HKCU、registry 讀寫、exit code 皆驗證
- **Smoke test（UI）**：三分頁渲染正確、Profile 自動選擇預設、翻譯 fallback 運作

## Smoke test 期間發現並修復的 bug

1. **`I18n.LoadLanguage` 清掉 `DefaultLanguage.xaml`** — 只在 Default 的新 key（TabProfile 等）在非英文 locale 失效，Tab headers 變空字串、寬度 0 不可見
2. **`I18n.LoadDictionary` 用 `Insert(0, ...)` 把 locale 放低優先位** — WPF MergedDictionaries 後 index 勝，locale 翻譯永遠被 Default 蓋掉
3. **`LEGUI.exe --shell-ext`（少參數）落入 AppConfig** — CLI parser 回 null 後 fall through 把 `--shell-ext` 當成檔案路徑，開 AppConfig

以上都在 `c73c129` 修復。

## Post-review 簡化（/simplify 找出的 7 項）

最後一個 commit `cf5d0ca` 處理三位 reviewer（Reuse / Quality / Efficiency）有共識的簡化：

1. `AboutPanel` 改用既有的 `GlobalHelper.GetVersionString()`
2. 抽 `ShellExtensionRegistrar.GetBuildOutputRoot()` helper（App + GlobalConfig 兩處重複的 basePath 計算）
3. 移除 `ShellExtensionPanel._query` 冗餘欄位，統一用 `_command`
4. `ShellExtCliCommand` 加 verb/scope 字串常數，消除魔術字串
5. `AppConfig.SaveSetting` 改用 `new LEProfile(true)` 預設值
6. `I18n.cs` 重複 comment 合併一處
7. `ProfileEditorControl._cultureInfos` / `_timezones` 改 static readonly（避免每個 UserControl 實例都跑 800+ 項的 `GetCultures`）

## 已知限制 / 後續追蹤

- 新增的 i18n key 只有 `DefaultLanguage.xaml`（英文）；22 個 locale 檔的翻譯由 Issue #21 處理
- `WithCREATESUSPENDED` 值的雙底線錯字在 22 個 locale 檔仍存在，待 Issue #21 一併修（已在 Issue #21 補 comment 說明）
- 真實互動測試（UAC 流程、Explorer 右鍵選單、舊 CLSID 殘留清理）需人工於 Windows Sandbox 驗證

## Scope 擴張說明

Issue 19 原始只要「加 Install UI」，本 PR 擴至 TabControl 重構 + `ProfileEditorControl` 抽出 + 版面修正，因為發現加 UI 會踩到既有重複版面問題，不如一起解決。

## 相關文件

- Spec: `docs/superpowers/specs/2026-04-18-legui-shell-extension-ui-and-layout-refactor-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-legui-shell-extension-ui-and-layout-refactor.md`

Closes #19