### PR TITLE
fix(LEGUI): 在 startup-error MessageBox 之前載入 locale，讓翻譯生效

### DIFF
--- a/src/LEGUI/App.xaml.cs
+++ b/src/LEGUI/App.xaml.cs
@@ -55,6 +55,10 @@ public partial class App : Application
 
         LEConfig.CheckGlobalConfigFile(true);
 
+        // Load locale dictionary before permission check so the error MessageBoxes
+        // below resolve in the user's language rather than always showing English.
+        I18n.LoadLanguage();
+
         // We check StandaloneFilePath before loading UI, because this wil be faster.
         if (
             !SystemHelper.CheckPermission(isGlobalProfile
@@ -105,8 +109,6 @@ public partial class App : Application
                 }
             }
         }
-
-        I18n.LoadLanguage();
 
         Current.StartupUri = isGlobalProfile
                                  ? new Uri("GlobalConfig.xaml", UriKind.RelativeOrAbsolute)


### PR DESCRIPTION
## 背景

PR #31 合併後，Final code reviewer 標出 **I-1 (Important)**：`App.xaml.cs` 的 3 個 startup-error MessageBox 在 `I18n.LoadLanguage()` 之前 fire，翻譯永遠無法生效。當時以 rare-trigger 為由延後處理，本 PR 做實際修正。

## 問題

`App_OnStartup` 原執行順序：

```
1. ShellExt CLI bypass 檢查（不需 UI）
2. args 解析
3. LEConfig.CheckGlobalConfigFile()
4. SystemHelper.CheckPermission() ← 失敗時觸發 3 個 MessageBox（含 I18n.Format / I18n.AppName）
5. I18n.LoadLanguage() ← 但到這裡才載入 locale dictionary！
6. Current.StartupUri = ...
```

結果：3 個 startup-error MessageBox（`ErrorInstallDirNotWritable`、`ErrorDirNotWritable`、`ErrorAdminRequired`）在步驟 4 fire，但 `I18n` 此時只有 `DefaultLanguage.xaml`（App.xaml 靜態 MergedDictionary）可查，**永遠 fall back 到英文**。21 locale 的這 3 個 key 翻譯等於白做。

## 修正

將 `I18n.LoadLanguage()` 提前到步驟 4 之前、步驟 3 之後（ShellExt CLI bypass 已在前面 return，不會誤觸發 locale 載入）：

```diff
         LEConfig.CheckGlobalConfigFile(true);

+        // Load locale dictionary before permission check so the error MessageBoxes
+        // below resolve in the user's language rather than always showing English.
+        I18n.LoadLanguage();
+
         // We check StandaloneFilePath before loading UI, because this wil be faster.
         if (
             !SystemHelper.CheckPermission(...
```

## 影響範圍

| 路徑 | 影響 |
|------|------|
| 正常啟動（有寫入權限） | LoadLanguage 從末尾移到中段，無可見差異 |
| 權限錯誤 → 3 個 MessageBox | ✅ **修好**：現在顯示使用者 locale 的翻譯，而非強制英文 |
| ShellExt CLI bypass | 無影響（在 LoadLanguage 之前就 return） |
| `OnStartup` unhandled exception handler | 無改動（那個是 AppDomain level，獨立事件） |

## Test Plan

- [x] `dotnet build src/LEGUI/`：0 errors
- [x] `dotnet test tests/LEGUI.Tests/`：68 / 68 pass（含 42 個 i18n completeness test）
- [x] 檢查修改後啟動流程：grep `I18n.LoadLanguage` 在 permission check 之前（line 60 vs 原 line 109）
- [x] CI 綠燈
- [ ] 手動觸發權限錯誤（例如把 LE 放在 Program Files 下，用非管理員執行）— 應顯示中文/日文/etc. 錯誤訊息 — 留待社群 / 後續 release smoke 驗證

## 相關

- PR #31（i18n 補全 — 本 fix 的前提）
- Issue #21（i18n 主 issue，已在 comment 標註 I-1 由本 PR 解決）
